### PR TITLE
Don't override terminal options for Gnuplot display.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,3 +16,4 @@ Naoki Nishida <domitry@gmail.com>
 Robby Clements <rclements@isotope11.com>
 Spacewander <spacewanderlzx@gmail.com>
 Takahiro Satoh <zalt50cc@gmail.com>
+Robert Haines <robert.haines@manchester.ac.uk>

--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -210,7 +210,10 @@ module IRuby
       type { Gnuplot::Plot }
       format 'image/svg+xml' do |obj|
         Tempfile.open('plot') do |f|
-          obj.terminal 'svg enhanced'
+          terminal = (obj['terminal'] || '').split(' ')
+          terminal[0] = 'svg'
+          terminal << 'enhanced' unless terminal.include?('noenhanced')
+          obj.terminal terminal.join(' ')
           obj.output f.path
           Gnuplot.open do |io|
             io << obj.to_gplot


### PR DESCRIPTION
I wanted to increase the size of my Gnuplot canvas but this can only be done via the terminal command and this was being overridden in the display code.

This commit allows the use of more options to the terminal command while ensuring that the terminal type is always set to svg and that enhanced mode is chosen unless explicitly turned off. This preserves the expected defaults provided by the previous implementation.