### PR TITLE
Add gnuplotrb support

### DIFF
--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -223,6 +223,12 @@ module IRuby
         end
       end
 
+      type { GnuplotRB::Plottable }
+      format 'image/svg+xml' do |obj|
+        options = obj.term ? obj.term[1] : {}
+        obj.to_svg(options)
+      end
+
       match do |obj|
         defined?(Magick::Image) && Magick::Image === obj ||
         defined?(MiniMagick::Image) && MiniMagick::Image === obj


### PR DESCRIPTION
Hi, I'm developing new visualization gem based on gnuplot as my GSoC 2015 project. It's placed here https://github.com/dilcom/gnuplotrb . In this pull request I want to add iRuby support for that plots.

This will make gnuplotrb usage in notebooks easier.