### PR TITLE
PryBackend syntax errors

### DIFF
--- a/lib/iruby/backend.rb
+++ b/lib/iruby/backend.rb
@@ -66,6 +66,11 @@ module IRuby
         reset
         raise SystemExit
       end
+      unless @pry.eval_string.empty?
+        syntax_error = @pry.eval_string
+        @pry.reset_eval_string
+        @pry.evaluate_ruby syntax_error
+      end
       raise @pry.last_exception if @pry.last_result_is_exception?
       @pry.push_initial_binding unless @pry.current_binding # ensure that we have a binding
       @pry.last_result


### PR DESCRIPTION
This block will return nil in IRuby despite the fact that it contains a syntax error: 

```ruby 
d = (-b + (((b**2) - (4*a*c)**(1/2)))/(2*a)
```

That's because the `pry` is normally used in a command line environment where lines are successively evaluated until a complete statement is reached. Things are a bit different in IRuby. This pull request patches `PryBackend` to immediately evaluate each `eval_string` instead of waiting on input. The kernel should now throw unterminated string and unexpected end-of-input syntax errors. 



The code block returns nil despite a syntax error because the . It's really hard to debug without the error message, especially if nil is a valid return for the block. 

