### PR TITLE
Convert Set to Array before using as header

### DIFF
--- a/lib/iruby/formatter.rb
+++ b/lib/iruby/formatter.rb
@@ -61,7 +61,8 @@ module IRuby
           rows << row
         end
 
-        if header = keys
+        if keys
+          header = keys.to_a
           keys.merge(0...array_size)
         else
           keys = 0...array_size


### PR DESCRIPTION
This is needed in cases where a table rendered using an Array of Hashes has more than `maxcols` columns. The error is `NoMethodError` with `Set#[]` on line 83, where header is indexed into.