### PR TITLE
Improve iruby dependency detection

### DIFF
--- a/lib/iruby/command.rb
+++ b/lib/iruby/command.rb
@@ -106,7 +106,7 @@ This might not work. Run 'iruby register --force' to fix it." if @iruby_path != 
     def check_bundler
       require 'bundler'
       raise %q{iruby is missing from Gemfile. This might not work.
-Add `gem 'iruby'` to your Gemfile to fix it.} unless Bundler.definition.dependencies.any? {|s| s.name == 'iruby' }
+Add `gem 'iruby'` to your Gemfile to fix it.} unless Bundler.definition.specs.any? {|s| s.name == 'iruby' }
       Bundler.setup
     rescue LoadError
     rescue Exception => e


### PR DESCRIPTION
`Bundler::Definition#dependencies` returns only top-level specs. It
doesn't include "iruby" gem if "iruby" is required by other gem.

`Bundler::Definition#specs` returns all depended gems. It includes
"iruby" gem even if "iruby" is required by other gem.