### PR TITLE
only complete text after a space

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -109,7 +109,7 @@ module IRuby
     def complete_request(msg)
       # HACK for #26, only complete last line
       code = msg[:content]['code']
-      if start = code.rindex("\n")
+      if start = code.rindex(/\s|\R/)
         code = code[start+1..-1]
         start += 1
       end


### PR DESCRIPTION
Fix the following behavior:

First, input ``a = Array.``[tab]
Then, chose ``Array.new``
Finally, ``a = `` is unfortunately deleted and only  ``Array.new`` remains.