### PR TITLE
Remove the DONTWAIT flag when receiving a message

### DIFF
--- a/lib/iruby/session/ffi_rzmq.rb
+++ b/lib/iruby/session/ffi_rzmq.rb
@@ -67,7 +67,7 @@ module IRuby
       while msg.empty? || socket.more_parts?
         begin
           frame = ''
-          rc = socket.recv_string(frame, 1)
+          rc = socket.recv_string(frame)
           ZMQ::Util.error_check('zmq_msg_send', rc)
           msg << frame
         rescue


### PR DESCRIPTION
This fixes #101, where IRuby would have 100% CPU usage when on ffi_rzmq.