### PR TITLE
Limit completion to stop notebook freezes

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -114,7 +114,7 @@ module IRuby
         start += 1
       end
       @session.send(:reply, :complete_reply,
-                    matches: @backend.complete(code),
+                    matches: @backend.complete(code).take(500),
                     status: :ok,
                     cursor_start: start.to_i,
                     cursor_end: msg[:content]['cursor_pos'])


### PR DESCRIPTION
This fixes an issue with Pry and jupyter notebook; tab completion can return >1000 suggestions (try "gibberish." + tab) which hangs the notebook for seconds. However it also affects the iruby console that does not need this fix.
I also created an issue in the jupyter/notebook repo: https://github.com/jupyter/notebook/issues/2136