### PR TITLE
Remove incorrect and bugged inspect_request

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -135,17 +135,6 @@ module IRuby
       @session.send(:reply, :history_reply, history: [])
     end
 
-    def inspect_request(msg)
-      result = @backend.eval(msg[:content]['code'])
-      @session.send(:reply, :inspect_reply,
-                    status: :ok,
-                    data: Display.display(result),
-                    metadata: {})
-    rescue Exception => e
-      IRuby.logger.warn "Inspection error: #{e.message}\n#{e.backtrace.join("\n")}"
-      @session.send(:reply, :inspect_reply, status: :error)
-    end
-
     def comm_open(msg)
       comm_id = msg[:content]['comm_id']
       target_name = msg[:content]['target_name']

--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -134,7 +134,11 @@ module IRuby
       # as requested in ipython/ipython#3806
       @session.send(:reply, :history_reply, history: [])
     end
-
+    
+    def inspect_request(msg)
+      @session.send(:reply, :inspect_reply, status: :ok, found: false, data: {}, metadata: {})
+    end
+    
     def comm_open(msg)
       comm_id = msg[:content]['comm_id']
       target_name = msg[:content]['target_name']


### PR DESCRIPTION
With the previous code, shift+tab on the notebook runs code silently instead of showing the documentation. It's not the intended function of inspect_request and might create confusion with users.
(according to https://jupyter-client.readthedocs.io/en/latest/messaging.html#introspection )

Also, @backend.eval is called with the wrong number of arguments (running on ruby 2.3.0 )