### PR TITLE
Fix integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: ruby
 
+addons:
+  apt:
+    sources:
+    - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_12.04/ ./'
+      key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_12.04/Release.key'
+    packages:
+    - libsodium-dev
+    - libczmq-dev
+
 rvm:
   - ruby-head
   - 2.2.2
@@ -7,8 +16,7 @@ rvm:
   - 2.0.0
 
 before_install:
-  - "sudo apt-get install libzmq3-dev"
-  - "sudo pip install 'ipython[notebook]'"
+  - "sudo pip install 'jupyter'"
 
 script: bundle exec rake
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ addons:
 
 rvm:
   - ruby-head
-  - 2.2.2
-  - 2.1.6
-  - 2.0.0
+  - 2.4.0
+  - 2.3.1
+  - 2.2.5
+  - 2.1.10
 
 before_install:
   - "sudo pip install 'jupyter'"

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,6 @@ group :plot do
   gem 'nyaplot', github: 'sciruby/nyaplot'
 end
 
+group :test do
+  gem 'cztop'
+end

--- a/jupyter_console_config.py
+++ b/jupyter_console_config.py
@@ -1,0 +1,1 @@
+c.InteractiveShell.colors = 'NoColor'

--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -106,6 +106,12 @@ module IRuby
         execution_count: @execution_count }
     end
 
+    def is_complete_request(msg)
+      # FIXME: the code completeness should be judged by using ripper or other Ruby parser
+      @session.send(:reply, :is_complete_reply,
+                    status: :unknown)
+    end
+
     def complete_request(msg)
       # HACK for #26, only complete last line
       code = msg[:content]['code']

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,40 +1,45 @@
 require 'test_helper'
-require 'open3'
+require 'pty'
 require 'expect'
 
 class IntegrationTest < IRubyTest
   def setup
-    @stdin, @stdout, @stderr, @process = Open3.popen3('bin/iruby')
+    $expect_verbose = false # make true if you want to dump the output of iruby console
+
+    @in, @out, pid = PTY.spawn('bin/iruby --config=jupyter_console_config.py')
+    @waiter = Thread.start { Process.waitpid(pid) }
     expect 'In [', 30
     expect '1'
     expect ']:'
   end
 
   def teardown
-    @stdin.close
-    @stdout.close
-    @stderr.close
-    @process.kill
+    @in.close
+    @out.close
+    @waiter.join
   end
 
   def write(input)
-    @stdin.puts input
+    @out.puts input
   end
 
-  def expect(pattern, timeout = 1)
-    assert @stdout.expect(pattern, timeout), "#{pattern} expected"
+  def expect(pattern, timeout = 10)
+    assert @in.expect(pattern, timeout), "#{pattern} expected, but timeout"
   end
 
   def test_interaction
     write '"Hello, world!"'
     expect '"Hello, world!"'
 
+    sleep 1
     write 'puts "Hello!"'
     expect 'Hello!'
 
+    sleep 1
     write '12 + 12'
     expect '24'
 
+    sleep 1
     write 'ls'
     expect 'self.methods'
   end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -27,19 +27,24 @@ class IntegrationTest < IRubyTest
     assert @in.expect(pattern, timeout), "#{pattern} expected, but timeout"
   end
 
+  def wait_prompt
+    expect 'In ['
+    expect ']:'
+  end
+
   def test_interaction
     write '"Hello, world!"'
     expect '"Hello, world!"'
 
-    sleep 1
+    wait_prompt
     write 'puts "Hello!"'
     expect 'Hello!'
 
-    sleep 1
+    wait_prompt
     write '12 + 12'
     expect '24'
 
-    sleep 1
+    wait_prompt
     write 'ls'
     expect 'self.methods'
   end


### PR DESCRIPTION
**MERGE #124 BEFORE MERGING THIS PULL-REQUEST**.

The latest jupyter console requires that stdout is a tty.
Using pty library this pull-request resolves the following error that is occurred in integration_test.rb

```console
irb(main):001:0> open('|bin/iruby')
=> #<IO:fd 9>
irb(main):002:0> /Users/mrkn/src/github.com/sciruby/iruby/bin/iruby differs from registered path /Users/mrkn/.rbenv/versions/2.4/bin/iruby.
This might not work. Run 'iruby register --force' to fix it.
[TerminalIPythonApp] WARNING | Subcommand `ipython console` is deprecated and will be removed in future versions.
[TerminalIPythonApp] WARNING | You likely want to use `jupyter console` in the future
Traceback (most recent call last):
  File "/Users/mrkn/.pyenv/versions/3.6.0/bin/ipython", line 11, in <module>
    sys.exit(start_ipython())
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/IPython/__init__.py", line 119, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/traitlets/config/application.py", line 657, in launch_instance
    app.initialize(argv)
  File "<decorator-gen-109>", line 2, in initialize
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/traitlets/config/application.py", line 87, in catch_config_error
    return method(app, *args, **kwargs)
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/IPython/terminal/ipapp.py", line 300, in initialize
    super(TerminalIPythonApp, self).initialize(argv)
  File "<decorator-gen-7>", line 2, in initialize
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/traitlets/config/application.py", line 87, in catch_config_error
    return method(app, *args, **kwargs)
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/IPython/core/application.py", line 446, in initialize
    self.parse_command_line(argv)
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/IPython/terminal/ipapp.py", line 295, in parse_command_line
    return super(TerminalIPythonApp, self).parse_command_line(argv)
  File "<decorator-gen-4>", line 2, in parse_command_line
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/traitlets/config/application.py", line 87, in catch_config_error
    return method(app, *args, **kwargs)
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/traitlets/config/application.py", line 514, in parse_command_line
    return self.initialize_subcommand(subc, subargv)
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/IPython/core/application.py", line 236, in initialize_subcommand
    return super(BaseIPythonApplication, self).initialize_subcommand(subc, argv)
  File "<decorator-gen-3>", line 2, in initialize_subcommand
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/traitlets/config/application.py", line 87, in catch_config_error
    return method(app, *args, **kwargs)
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/traitlets/config/application.py", line 452, in initialize_subcommand
    self.subapp.initialize(argv)
  File "<decorator-gen-113>", line 2, in initialize
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/traitlets/config/application.py", line 87, in catch_config_error
    return method(app, *args, **kwargs)
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/jupyter_console/app.py", line 141, in initialize
    self.init_shell()
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/jupyter_console/app.py", line 114, in init_shell
    client=self.kernel_client,
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/traitlets/config/configurable.py", line 412, in instance
    inst = cls(*args, **kwargs)
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/jupyter_console/ptshell.py", line 271, in __init__
    self.init_prompt_toolkit_cli()
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/jupyter_console/ptshell.py", line 425, in init_prompt_toolkit_cli
    output=create_output(true_color=self.true_color),
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/prompt_toolkit/shortcuts.py", line 126, in create_output
    ansi_colors_only=ansi_colors_only, term=term)
  File "/Users/mrkn/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/prompt_toolkit/terminal/vt100_output.py", line 424, in from_pty
    assert stdout.isatty()
AssertionError
```

Moreover in this pull-request, I've modified .travis.yml about dependencies and ruby versions to be up-to-date.

- [x] Use cztop
- [x] Fix test code
- [x] Fix .travis.yml