### PR TITLE
Check arity of :path method

### DIFF
--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -284,7 +284,7 @@ module IRuby
         obj.to_iruby
       end
 
-      match {|obj| obj.respond_to?(:path) && File.readable?(obj.path) }
+      match {|obj| obj.respond_to?(:path) && obj.method(:path).arity == 0 && File.readable?(obj.path) }
       format do |obj|
         mime = MimeMagic.by_path(obj.path).to_s
         [mime, File.read(obj.path)] if SUPPORTED_MIMES.include?(mime)


### PR DESCRIPTION
Without this arity check, display errors can result (for instance, many of the objects defined in the `ruby-git` gem define a `.path` method requiring exactly one argument.)

Note: It is questionable whether the the entire idea of supporting `.path` is wise...  this PR attempts a minimal fix, but I would also suggest the maintainers consider simply removing the logic all together.