### PR TITLE
Message protocol 5 dosen't use 'source' field

### DIFF
--- a/lib/iruby/utils.rb
+++ b/lib/iruby/utils.rb
@@ -7,8 +7,7 @@ module IRuby
     def display(obj, options = {})
       Kernel.instance.session.send(:publish, :display_data,
                                    data: Display.display(obj, options),
-                                   metadata: {},
-                                   source: 'ruby') unless obj.nil?
+                                   metadata: {}) unless obj.nil?
     end
 
     def table(s, **options)


### PR DESCRIPTION
I think this patch will reduce error messages.
https://github.com/IRkernel/IRkernel/pull/523
![image](https://user-images.githubusercontent.com/5798442/52406454-1481cc80-2b11-11e9-9f69-52bf2b524388.png)
