### PR TITLE
remove old screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 IRuby is a Ruby kernel for [Jupyter project](http://try.jupyter.org/).
 
-![Screenshot](https://cloud.githubusercontent.com/assets/50754/7956845/3fa46df8-09e3-11e5-8641-f5b8669061b5.png)
-
 ## Installation
 How to set up [ZeroMQ](http://zeromq.org/) depends on your environment.
 You can use one of the following libraries. 


### PR DESCRIPTION
Hello.
I deleted the screenshot of the old IPython Notebook.
(It gives the impression that it has not been updated.)

Perhaps we should add a new screenshot so that anyone can see the Ruby icon at a glance.
However, I have no idea of a good screen shot for now.