### PR TITLE
remove execution_count on error messages

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -102,8 +102,7 @@ module IRuby
       { status: :error,
         ename: e.class.to_s,
         evalue: e.message,
-        traceback: ["#{RED}#{e.class}#{RESET}: #{e.message}", *e.backtrace.map { |l| "#{WHITE}#{l}#{RESET}" }],
-        execution_count: @execution_count }
+        traceback: ["#{RED}#{e.class}#{RESET}: #{e.message}", *e.backtrace.map { |l| "#{WHITE}#{l}#{RESET}" }] }
     end
 
     def is_complete_request(msg)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5798442/52691974-ea635b00-2fa5-11e9-91f9-6dd4f215ee78.png)

The `error` message type shouldn't have an `execution_count` field.
Thanks to IRKernel developers.
https://github.com/IRkernel/IRkernel/pull/564