### PR TITLE
Fix Execution error messages on the IOPub (PUB/SUB) channel

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -94,6 +94,7 @@ module IRuby
       rescue Exception => e
         content = error_content(e)
         @session.send(:publish, :error, content)
+        content[:status] = :error
       end
       @session.send(:reply, :execute_reply, content)
       @session.send(:publish, :execute_result,

--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -53,7 +53,7 @@ module IRuby
       end
     rescue Exception => e
       IRuby.logger.debug "Kernel error: #{e.message}\n#{e.backtrace.join("\n")}"
-      @session.send(:publish, :error, error_message(e))
+      @session.send(:publish, :error, error_content(e))
     end
 
     def kernel_info_request(msg)
@@ -92,7 +92,7 @@ module IRuby
       rescue SystemExit
         content[:payload] << { source: :ask_exit }
       rescue Exception => e
-        content = error_message(e)
+        content = error_content(e)
         @session.send(:publish, :error, content)
       end
       @session.send(:reply, :execute_reply, content)
@@ -102,9 +102,8 @@ module IRuby
                     execution_count: @execution_count) unless result.nil? || msg[:content]['silent']
     end
 
-    def error_message(e)
-      { status: :error,
-        ename: e.class.to_s,
+    def error_content(e)
+      { ename: e.class.to_s,
         evalue: e.message,
         traceback: ["#{RED}#{e.class}#{RESET}: #{e.message}", *e.backtrace.map { |l| "#{WHITE}#{l}#{RESET}" }] }
     end


### PR DESCRIPTION
Hello.

I removed `'status' : 'error'`, from error messages on the IOPub (PUB/SUB) channel. 
This fix may reduce error messages such as:
```terminal
[E 15:09:38.972 LabApp] Notebook JSON is invalid: Additional properties are not allowed ('status' was unexpected)
    
    Failed validating 'additionalProperties' in error:
    
    On instance['cells'][4]['outputs'][0]:
    {'ename': 'NoMethodError',
     'evalue': "undefined method `mojojo' for []:Array",
     'output_type': 'error',
     'status': 'error',
     'traceback': ["\x1b[31mNoMethodError\x1b[0m: undefined method `meow' for Cow" ...
```

IRuby sends two error messages to the shell channel and the IOPub channel.
These messages are similar. But messages sent to the IOPub channel should not include status.

https://jupyter-client.readthedocs.io/en/stable/messaging.html#execution-errors

>  content = {
>     # Similar content to the execute_reply messages for the 'error' case,
>     # except the 'status' field is omitted.
>  }



