### PR TITLE
Reduce error messages when bundler is not found

### DIFF
--- a/lib/iruby/command.rb
+++ b/lib/iruby/command.rb
@@ -104,7 +104,7 @@ Try `ipython help` for more information.
       Dir.chdir(working_dir) if working_dir
 
       require boot_file if boot_file
-      check_bundler {|e| IRuby.logger.warn "Could not load bundler: #{e.message}\n#{e.backtrace.join("\n")}" }
+      check_bundler {|e| IRuby.logger.warn "Could not load bundler: #{e.message}" }
 
       require 'iruby'
       Kernel.new(config_file).run


### PR DESCRIPTION
This fix suppresses the error trace when the Gemfile is not found.

New error log
```
W, [2019-05-27T10:50:52.324791 #12313]  WARN -- : Could not load bundler: Could not locate Gemfile or .bundle/ directory
```

pervious error log
```
W, [2019-05-27T10:43:44.947721 #12048]  WARN -- : Eould not load bundler: Could not locate Gemfile or .bundle/ directory
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.0.1/lib/bundler.rb:237:in `rescue in root'
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.0.1/lib/bundler.rb:233:in `root'
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.0.1/lib/bundler.rb:80:in `bundle_path'
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.0.1/lib/bundler.rb:554:in `configure_gem_home'
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.0.1/lib/bundler.rb:535:in `configure_gem_home_and_path'
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.0.1/lib/bundler.rb:66:in `configure'
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-2.0.1/lib/bundler.rb:134:in `definition'
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/iruby-0.3/lib/iruby/command.rb:149:in `check_bundler'
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/iruby-0.3/lib/iruby/command.rb:107:in `run_kernel'
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/iruby-0.3/lib/iruby/command.rb:40:in `run'
/Users/kojix2/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/iruby-0.3/bin/iruby:5:in `<top (required)>'
/Users/kojix2/.rbenv/versions/2.6.3/bin/iruby:23:in `load'
/Users/kojix2/.rbenv/versions/2.6.3/bin/iruby:23:in `<main>'
```

Many people are pointing out this problem.
#91
#144