### PR TITLE
Remove white tracebacks

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -1,7 +1,6 @@
 module IRuby
   class Kernel
     RED = "\e[31m"
-    WHITE = "\e[37m"
     RESET = "\e[0m"
 
     class<< self
@@ -106,7 +105,7 @@ module IRuby
     def error_content(e)
       { ename: e.class.to_s,
         evalue: e.message,
-        traceback: ["#{RED}#{e.class}#{RESET}: #{e.message}", *e.backtrace.map { |l| "#{WHITE}#{l}#{RESET}" }] }
+        traceback: ["#{RED}#{e.class}#{RESET}: #{e.message}", *e.backtrace] }
     end
 
     def is_complete_request(msg)


### PR DESCRIPTION
Per issue #208. 

@kojix2 I *think* this is correct. I was able to get it running with 

```
bundle install
bundle exec iruby register --force
bundle exec jupyter console --kernel ruby
```

Slightly concerning is that the kernel crashed with a message about `execution_count` after I triggered an error; please see the full output below. This actually caused the Jupyter console to exit. Maybe things are unstable on `master`?


```
Jupyter console 6.0.0

IRuby 0.3 (with ffirzmq session adapter)


In [1]: 2 + 2
Out[1]: 4

In [2]: require('asdf')
LoadError: cannot load such file -- asdf
(pry):2:in `require'
(pry):2:in `<main>'
/home/tom/tools/iruby/vendor/bundle/ruby/2.6.0/gems/pry-0.11.3/lib/pry/pry_instance.rb:355:in `eval'
/home/tom/tools/iruby/vendor/bundle/ruby/2.6.0/gems/pry-0.11.3/lib/pry/pry_instance.rb:355:in `evaluate_ruby'
/home/tom/tools/iruby/vendor/bundle/ruby/2.6.0/gems/pry-0.11.3/lib/pry/pry_instance.rb:323:in `handle_line'
/home/tom/tools/iruby/vendor/bundle/ruby/2.6.0/gems/pry-0.11.3/lib/pry/pry_instance.rb:243:in `block (2 levels) in eval'
/home/tom/tools/iruby/vendor/bundle/ruby/2.6.0/gems/pry-0.11.3/lib/pry/pry_instance.rb:242:in `catch'
/home/tom/tools/iruby/vendor/bundle/ruby/2.6.0/gems/pry-0.11.3/lib/pry/pry_instance.rb:242:in `block in eval'
/home/tom/tools/iruby/vendor/bundle/ruby/2.6.0/gems/pry-0.11.3/lib/pry/pry_instance.rb:241:in `catch'
/home/tom/tools/iruby/vendor/bundle/ruby/2.6.0/gems/pry-0.11.3/lib/pry/pry_instance.rb:241:in `eval'
/home/tom/tools/iruby/lib/iruby/backend.rb:66:in `eval'
/home/tom/tools/iruby/lib/iruby/backend.rb:12:in `eval'
/home/tom/tools/iruby/lib/iruby/kernel.rb:90:in `execute_request'
/home/tom/tools/iruby/lib/iruby/kernel.rb:49:in `dispatch'
/home/tom/tools/iruby/lib/iruby/kernel.rb:38:in `run'
/home/tom/tools/iruby/lib/iruby/command.rb:110:in `run_kernel'
/home/tom/tools/iruby/lib/iruby/command.rb:40:in `run'
/home/tom/tools/iruby/bin/iruby:5:in `<top (required)>'
/home/tom/tools/iruby/vendor/bundle/ruby/2.6.0/bin/iruby:23:in `load'
/home/tom/tools/iruby/vendor/bundle/ruby/2.6.0/bin/iruby:23:in `<main>'
Traceback (most recent call last):
  File "/home/tom/.local/bin/jupyter-console", line 10, in <module>
    sys.exit(main())
  File "/home/tom/.local/lib/python3.7/site-packages/jupyter_core/application.py", line 266, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/home/tom/.local/lib/python3.7/site-packages/traitlets/config/application.py", line 658, in launch_instance
    app.start()
  File "/home/tom/.local/lib/python3.7/site-packages/jupyter_console/app.py", line 156, in start
    self.shell.mainloop()
  File "/home/tom/.local/lib/python3.7/site-packages/jupyter_console/ptshell.py", line 552, in mainloop
    self.interact()
  File "/home/tom/.local/lib/python3.7/site-packages/jupyter_console/ptshell.py", line 544, in interact
    self.run_cell(code, store_history=True)
  File "/home/tom/.local/lib/python3.7/site-packages/jupyter_console/ptshell.py", line 608, in run_cell
    self.handle_execute_reply(msg_id, timeout=0.05)
  File "/home/tom/.local/lib/python3.7/site-packages/jupyter_console/ptshell.py", line 646, in handle_execute_reply
    self.execution_count = int(content["execution_count"] + 1)
KeyError: 'execution_count'
```