### PR TITLE
Add execution_count on reply error messages. 

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -94,6 +94,7 @@ module IRuby
         content = error_content(e)
         @session.send(:publish, :error, content)
         content[:status] = :error
+        content[:execution_count] = @execution_count
       end
       @session.send(:reply, :execute_reply, content)
       @session.send(:publish, :execute_result,


### PR DESCRIPTION
Bug
* Jupyter console crashes when an error occurs. 
* Jupyter notebook does not display cell numbers when an error occurs.

reported by @thomasjm
https://github.com/SciRuby/iruby/pull/209#issue-300525456

Fix

Request-reply error messages requires an `execution_count` field.
On the other hand, IOPub error messages should not contain an `execution_count` field.

I deleted both at #179. I'm sorry. 