### PR TITLE
Fix LoadError in pyzma_adapter

### DIFF
--- a/lib/iruby/session_adapter/pyzmq_adapter.rb
+++ b/lib/iruby/session_adapter/pyzmq_adapter.rb
@@ -1,14 +1,19 @@
 module IRuby
   module SessionAdapter
     class PyzmqAdapter < BaseAdapter
-      def self.load_requirements
-        require 'pycall'
-        @zmq = PyCall.import_module('zmq')
-      rescue PyCall::PyError => error
-        raise LoadError, error.message
-      end
 
       class << self
+        def load_requirements
+          require 'pycall'
+          import_pyzmq
+        end
+
+        def import_pyzmq
+          @zmq = PyCall.import_module('zmq')
+        rescue PyCall::PyError => error
+          raise LoadError, error.message
+        end
+
         attr_reader :zmq
       end
 


### PR DESCRIPTION
Try to fix #217 @kozo2 @mrkn 

1. If IRuby fails to load `ffi-rzmq`, `cztop`, and `rbczmq`, it tries to load `pyzmq_adapter`.
https://github.com/SciRuby/iruby/blob/8e8b58d50590fd739d3b4ca46c0e01fd1af0cdab/lib/iruby/session_adapter.rb#L42-L48
https://github.com/SciRuby/iruby/blob/8e8b58d50590fd739d3b4ca46c0e01fd1af0cdab/lib/iruby/session_adapter.rb#L62-L64
2. If `pycall` is not installed, `LoadError` occurs (Line 5).
https://github.com/SciRuby/iruby/blob/8e8b58d50590fd739d3b4ca46c0e01fd1af0cdab/lib/iruby/session_adapter/pyzmq_adapter.rb#L1-L9
3. Then the exception handler checks for `PyCall::PyError`  (Line 7). However, if pycall is not installed, there is no `PyCall` constant and a `NameError` occurs.
```
uninitialized constant IRuby::SessionAdapter::PyzmqAdapter::PyCall (NameError)
```
5. Because `session_adapter.rb` does not check for `NameError`, it cannot determine whether `pyzmq _adapter` is available or not.
https://github.com/SciRuby/iruby/blob/8e8b58d50590fd739d3b4ca46c0e01fd1af0cdab/lib/iruby/session_adapter.rb#L4-L11

I think this pull request will solves the problem, but I haven't seen PyCall work yet(#218).
Please review it. Thank you.