### PR TITLE
add clear_output to Utils

### DIFF
--- a/lib/iruby/utils.rb
+++ b/lib/iruby/utils.rb
@@ -10,6 +10,10 @@ module IRuby
                                    metadata: {}) unless obj.nil?
     end
 
+    def clear_output(wait=false)
+      Display.clear_output(wait)
+    end
+
     def table(s, **options)
       html(HTML.table(s, options))
     end


### PR DESCRIPTION
#207
Allow clear_output to be called from IRuby module. 

You can use it in the same way as IJulia.
https://github.com/JuliaLang/IJulia.jl#clearing-output
```Julia
IJulia.clear_output(wait=false)
```