### PR TITLE
remove nyaplot from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ end
 group :plot do
   gem 'gnuplot'
   gem 'rubyvis'
-  gem 'nyaplot', github: 'sciruby/nyaplot'
 end
 
 group :test do


### PR DESCRIPTION
Nyaplot is no longer maintained and is not recommended for use.
There are some bugs that are not likely to be fixed.

https://github.com/SciRuby/iruby/blob/d87fdba8758e1337b159ffb25b2e89318dfcf3a7/iruby.gemspec#L21-L23
IRuby shows gems in the Gemfile during installation

Plotting libraries in 2019

* daru-view
* pycall + seaborn
* numo-gnuplot
* iruby-plotly
* gnuplotrb