### PR TITLE
remove In Out from top-level

### DIFF
--- a/lib/iruby/backend.rb
+++ b/lib/iruby/backend.rb
@@ -1,6 +1,5 @@
 module IRuby
   In, Out = [nil], [nil]
-  ::In, ::Out = In, Out
 
   module History
     def eval(code, store_history)


### PR DESCRIPTION
IRuby defines `In`, `Out` constants at the top-level.

![image](https://user-images.githubusercontent.com/5798442/63640588-d169fe00-c6dc-11e9-96da-b25979b7906e.png)

These actually access `IRuby::In`, `IRuby:: Out`.
My opinion is that we should remove these common name constants from the top-level. I think It can cause bugs and mistakes.

But, compatibility is important. We need to consider a number of factors. There may be things I do not understand about these constants.

What do you think?