### PR TITLE
Fixed warnings when running minitest

### DIFF
--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -91,7 +91,7 @@ module IRuby
     end
 
     class Renderer
-      attr_reader :match, :mime, :render, :priority
+      attr_reader :match, :mime, :priority
 
       def initialize(match, mime, render, priority)
         @match, @mime, @render, @priority = match, mime, render, priority
@@ -291,7 +291,7 @@ module IRuby
       end
 
       type { Object }
-      priority -1000
+      priority(-1000)
       format 'text/plain' do |obj|
         obj.inspect
       end

--- a/lib/iruby/input.rb
+++ b/lib/iruby/input.rb
@@ -15,21 +15,21 @@ module IRuby
     end
 
     def form &block
-      builder = Builder.new &block
+      builder = Builder.new(&block)
       form = InputForm.new(
-        fields: builder.fields, 
+        fields: builder.fields,
         buttons: builder.buttons
       )
       form.widget_display
       builder.process_result form.submit
     end
-       
+
     def popup title='Input', &block
-      builder = Builder.new &block
+      builder = Builder.new(&block)
       form = InputForm.new fields: builder.fields
       popup = Popup.new(
-        title: title, 
-        form: form, 
+        title: title,
+        form: form,
         buttons: builder.buttons
       )
       popup.widget_display

--- a/lib/iruby/session_adapter/pyzmq_adapter.rb
+++ b/lib/iruby/session_adapter/pyzmq_adapter.rb
@@ -25,10 +25,6 @@ module IRuby
         make_socket(:PUB, protocol, host, port)
       end
 
-      def make_pub_socket(protocol, host, port)
-        make_socket(:REP, protocol, host, port)
-      end
-
       def heartbeat_loop(sock)
         PyCall.sys.path.append(File.expand_path('../pyzmq', __FILE__))
         heartbeat = PyCall.import_module('iruby.heartbeat')


### PR DESCRIPTION
Fixed warnings when running minitest

```bash
iruby/lib/iruby/input.rb:18: warning: `&' interpreted as argument prefix
iruby/lib/iruby/input.rb:28: warning: `&' interpreted as argument prefix
iruby/lib/iruby/display.rb:294: warning: ambiguous first argument; put parentheses or a space even after `-' operator
iruby/lib/iruby/display.rb:104: warning: method redefined; discarding old render
iruby/lib/iruby/session_adapter/pyzmq_adapter.rb:28: warning: method redefined; discarding old make_pub_socket
iruby/lib/iruby/session_adapter/pyzmq_adapter.rb:24: warning: previous definition of make_pub_socket was here
```