### PR TITLE
fix: PR#249 depends on ruby2.6 infinite rage syntax

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -111,7 +111,8 @@ module IRuby
     end
 
     def error_content(e)
-      backtrace = e.backtrace[0..e.backtrace.rindex{|line| line.start_with?(@backend.eval_path)}]
+      rindex = e.backtrace.rindex{|line| line.start_with?(@backend.eval_path)} || -1
+      backtrace = e.backtrace[0..rindex]
       { ename: e.class.to_s,
         evalue: e.message,
         traceback: ["#{RED}#{e.class}#{RESET}: #{e.message}", *backtrace] }


### PR DESCRIPTION
https://github.com/SciRuby/iruby/pull/249

Sorry, my code depends on ruby2.6’s new infinite range syntax, it doesn't work well with ruby2.5.

https://github.com/zheng-yongping/iruby/blob/ac9763bbde4c7ce84c593cc376da2233c65e42c1/lib/iruby/kernel.rb#L108

when rindex return nil => ArgumentError (bad value for range)
