### PR TITLE
Set the default format for NArray to 'text/plain'.

### DIFF
--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -170,6 +170,9 @@ module IRuby
       end
 
       type { Numo::NArray }
+      format 'text/plain' do |obj|
+        obj.inspect
+      end
       format 'text/latex' do |obj|
         obj.ndim == 2 ?
         LaTeX.matrix(obj, obj.shape[0], obj.shape[1]) :
@@ -180,6 +183,9 @@ module IRuby
       end
 
       type { NArray }
+      format 'text/plain' do |obj|
+        obj.inspect
+      end
       format 'text/latex' do |obj|
         obj.dim == 2 ?
         LaTeX.matrix(obj.transpose(1, 0), obj.shape[1], obj.shape[0]) :


### PR DESCRIPTION
Fix #197
Related to #227 (Thanks to @mrkn)
Related to https://github.com/ruby-numo/numo-narray/issues/124 

Sets the default display format for NArray to plain text.
This change will be very useful when working with large Narray in IRuby.