### PR TITLE
Ffi rzmq runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ IRuby is a Ruby kernel for [Jupyter project](http://try.jupyter.org/).
     * [ffi-rzmq](https://github.com/chuckremes/ffi-rzmq) and [libzmq](https://github.com/zeromq/libzmq)
     * [CZTop](https://gitlab.com/paddor/cztop) and [CZMQ](https://github.com/zeromq/czmq)
 
+If both ffi-rzmq and cztop are installed, ffi-rzmq is used. If you prefer cztop, set the following environment variable.
+```sh
+export IRUBY_SESSION_ADAPTER="cztop"
+```
+
 We recommend the [Pry](https://github.com/pry/pry) backend for full functionality.
 
 ### Ubuntu

--- a/iruby.gemspec
+++ b/iruby.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json', '~> 1.11'
   s.add_dependency 'mimemagic', '~> 0.3'
   s.add_dependency 'data_uri', '~> 0.1'
+  s.add_dependency 'ffi-rzmq'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'
-  s.add_development_dependency 'ffi-rzmq'
   s.add_development_dependency 'pycall', '>= 1.2.1'
 end

--- a/iruby.gemspec
+++ b/iruby.gemspec
@@ -10,20 +10,20 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/SciRuby/iruby'
   s.license       = 'MIT'
 
-  s.files         = `git ls-files`.split($/)
+  s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^test/})
-  s.require_paths = %w(lib)
+  s.require_paths = %w[lib]
 
   s.required_ruby_version = '>= 2.3.0'
 
   s.add_dependency 'bond', '~> 0.5'
-  s.add_dependency 'multi_json', '~> 1.11'
-  s.add_dependency 'mimemagic', '~> 0.3'
   s.add_dependency 'data_uri', '~> 0.1'
   s.add_dependency 'ffi-rzmq'
+  s.add_dependency 'mimemagic', '~> 0.3'
+  s.add_dependency 'multi_json', '~> 1.11'
 
-  s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'pycall', '>= 1.2.1'
+  s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
This pull request adds ffi-rzmq to the runtime dependency. 
Reinstalling ffi-rzmq when updating Ruby is very inconvenient.

Users of cztop can set environment variables. This is documented in the README.

Reported by @kozo2