### PR TITLE
Revert "support_ruby_2.2_again" #263

### DIFF
--- a/iruby.gemspec
+++ b/iruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^test/})
   s.require_paths = %w[lib]
 
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.3.0'
 
   s.add_dependency 'bond', '~> 0.5'
   s.add_dependency 'data_uri', '~> 0.1'


### PR DESCRIPTION
This reverts commit a972dc508cf28ff3aba35ecb3bc81efa7d13a1c5.