### PR TITLE
Replace Bond with IRB

### DIFF
--- a/iruby.gemspec
+++ b/iruby.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'bond', '~> 0.5'
   s.add_dependency 'data_uri', '~> 0.1'
   s.add_dependency 'ffi-rzmq'
   s.add_dependency 'mimemagic', '~> 0.3'

--- a/lib/iruby/backend.rb
+++ b/lib/iruby/backend.rb
@@ -36,17 +36,20 @@ module IRuby
     prepend History
 
     def initialize
-      require 'bond'
-      Bond.start(debug: true)
-      @eval_path = '(iruby)'
+      require 'irb'
+      require 'irb/completion'
+      IRB.setup(nil)
+      @irb = IRB::Irb.new
+      IRB.conf[:MAIN_CONTEXT] = @irb.context
     end
 
     def eval(code, store_history)
-      TOPLEVEL_BINDING.eval(code, @eval_path, 1)
+      @irb.context.evaluate(code, 0)
+      @irb.context.last_value
     end
 
     def complete(code)
-      Bond.agent.call(code, code)
+      IRB::InputCompletor::CompletionProc.call(code)
     end
   end
 

--- a/lib/iruby/ostream.rb
+++ b/lib/iruby/ostream.rb
@@ -46,6 +46,11 @@ module IRuby
       lines.each { |s| write(s) }
     end
 
+    # Called by irb
+    def set_encoding(extern, intern)
+      a = extern
+    end
+
     private
 
     def build_string


### PR DESCRIPTION
This pull request replaces bond with IRB. Bond is a gem that hasn't been updated in 6 years, requires a native extension, and does not compile with MSVC. Instead, the PlainBackend is switched over to IRB which is installed with Ruby.