### PR TITLE
Stop using mimemagic

### DIFF
--- a/iruby.gemspec
+++ b/iruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bond', '~> 0.5'
   s.add_dependency 'data_uri', '~> 0.1'
   s.add_dependency 'ffi-rzmq'
-  s.add_dependency 'mimemagic', '~> 0.3'
+  s.add_dependency 'mime-types', '>= 3.3.1'
   s.add_dependency 'multi_json', '~> 1.11'
 
   s.add_development_dependency 'pycall', '>= 1.2.1'

--- a/lib/iruby.rb
+++ b/lib/iruby.rb
@@ -1,4 +1,4 @@
-require 'mimemagic'
+require 'mime/types'
 require 'multi_json'
 require 'securerandom'
 require 'openssl'

--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -44,7 +44,7 @@ module IRuby
       private
 
       def protect(mime, data)
-        MimeMagic.new(mime).text? ? data.to_s : [data.to_s].pack('m0')
+        MIME::Type.new(mime).ascii? ? data.to_s : [data.to_s].pack('m0')
       end
 
       def render(data, obj, exact_mime, fuzzy_mime)
@@ -304,7 +304,7 @@ module IRuby
 
       match { |obj| obj.respond_to?(:path) && obj.method(:path).arity == 0 && File.readable?(obj.path) }
       format do |obj|
-        mime = MimeMagic.by_path(obj.path).to_s
+        mime = MIME::Types.of(obj.path).first.to_s
         [mime, File.read(obj.path)] if SUPPORTED_MIMES.include?(mime)
       end
 

--- a/test/iruby/mime_test.rb
+++ b/test/iruby/mime_test.rb
@@ -1,0 +1,32 @@
+class IRubyTest::MimeTest < IRubyTest::TestBase
+  sub_test_case("IRuby::Display") do
+    def test_display_with_mime_type
+      html = "<b>Bold Text</b>"
+
+      obj = Object.new
+      obj.define_singleton_method(:to_s) { html }
+
+      res = IRuby::Display.display(obj, mime: "text/html")
+      assert_equal({ plain: obj.inspect,       html: html },
+                   { plain: res["text/plain"], html: res["text/html"] })
+    end
+  end
+
+  sub_test_case("Rendering a file") do
+    def setup
+      @html = "<b>Bold Text</b>"
+      Dir.mktmpdir do |tmpdir|
+        @file = File.join(tmpdir, "test.html")
+        File.write(@file, @html)
+        yield
+      end
+    end
+
+    def test_display
+      File.open(@file, "rb") do |f|
+        res = IRuby::Display.display(f)
+        assert_equal(@html, res["text/html"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
To avoid troubles due to the licensing issue of mimemagic, I'd like to stop using it.
I guess mime-types is an appropriate replacement.