### PR TITLE
Make application/javascript a text type

### DIFF
--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -44,7 +44,18 @@ module IRuby
       private
 
       def protect(mime, data)
-        MIME::Type.new(mime).ascii? ? data.to_s : [data.to_s].pack('m0')
+        ascii?(mime) ? data.to_s : [data.to_s].pack('m0')
+      end
+
+      def ascii?(mime)
+        case mime
+        when "application/javascript"
+          # Special case for application/javascript.
+          # This needs because mime-types tells us application/javascript a non-text type.
+          true
+        else
+          MIME::Type.new(mime).ascii?
+        end
       end
 
       def render(data, obj, exact_mime, fuzzy_mime)

--- a/test/iruby/mime_test.rb
+++ b/test/iruby/mime_test.rb
@@ -1,14 +1,25 @@
 class IRubyTest::MimeTest < IRubyTest::TestBase
   sub_test_case("IRuby::Display") do
-    def test_display_with_mime_type
-      html = "<b>Bold Text</b>"
+    sub_test_case(".display") do
+      sub_test_case("with mime type") do
+        test("text/html") do
+          html = "<b>Bold Text</b>"
 
-      obj = Object.new
-      obj.define_singleton_method(:to_s) { html }
+          obj = Object.new
+          obj.define_singleton_method(:to_s) { html }
 
-      res = IRuby::Display.display(obj, mime: "text/html")
-      assert_equal({ plain: obj.inspect,       html: html },
-                   { plain: res["text/plain"], html: res["text/html"] })
+          res = IRuby::Display.display(obj, mime: "text/html")
+          assert_equal({ plain: obj.inspect,       html: html },
+                       { plain: res["text/plain"], html: res["text/html"] })
+        end
+
+        test("application/javascript") do
+          data = "alert('Hello World!')"
+          res = IRuby::Display.display(data, mime: "application/javascript")
+          assert_equal(data,
+                       res["application/javascript"])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
While mime-types handles application/javascript as a non-text, IRuby needs to
handle it as a text.

The new `ascii?` private method judges whether the given mime type is text.
This method handles application/javascript as a text in the special case.

[Fix GH-292]