### PR TITLE
Hooks around of execution

### DIFF
--- a/lib/iruby.rb
+++ b/lib/iruby.rb
@@ -7,6 +7,7 @@ require 'set'
 
 require 'iruby/version'
 require 'iruby/jupyter'
+require 'iruby/event_manager'
 require 'iruby/kernel'
 require 'iruby/backend'
 require 'iruby/ostream'

--- a/lib/iruby/event_manager.rb
+++ b/lib/iruby/event_manager.rb
@@ -1,0 +1,40 @@
+module IRuby
+  class EventManager
+    def initialize(available_events)
+      @available_events = available_events.dup.freeze
+      @callbacks = available_events.map {|n| [n, []] }.to_h
+    end
+
+    attr_reader :available_events
+
+    def register(event, &block)
+      check_available_event(event)
+      @callbacks[event] << block unless block.nil?
+      block
+    end
+
+    def unregister(event, callback)
+      check_available_event(event)
+      val = @callbacks[event].delete(callback)
+      unless val
+        raise ArgumentError,
+              "Given callable object #{callback} is not registered as a #{event} callback"
+      end
+      val
+    end
+
+    def trigger(event, *args, **kwargs)
+      check_available_event(event)
+      @callbacks[event].each do |fn|
+        fn.call(*args, **kwargs)
+      end
+    end
+
+    private
+
+    def check_available_event(event)
+      return if @callbacks.key?(event)
+      raise ArgumentError, "Unknown event name: #{event}", caller
+    end
+  end
+end

--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -9,12 +9,12 @@ module IRuby
 
     attr_reader :session
 
-    def initialize(config_file)
+    def initialize(config_file, session_adapter_name=nil)
       @config = MultiJson.load(File.read(config_file))
       IRuby.logger.debug("IRuby kernel start with config #{@config}")
       Kernel.instance = self
 
-      @session = Session.new(@config)
+      @session = Session.new(@config, session_adapter_name)
       $stdout = OStream.new(@session, :stdout)
       $stderr = OStream.new(@session, :stderr)
 

--- a/lib/iruby/session_adapter.rb
+++ b/lib/iruby/session_adapter.rb
@@ -10,6 +10,10 @@ module IRuby
         false
       end
 
+      def self.load_requirements
+        # Do nothing
+      end
+
       def initialize(config)
         @config = config
       end
@@ -37,12 +41,14 @@ module IRuby
     require_relative 'session_adapter/ffirzmq_adapter'
     require_relative 'session_adapter/cztop_adapter'
     require_relative 'session_adapter/pyzmq_adapter'
+    require_relative 'session_adapter/test_adapter'
 
     def self.select_adapter_class(name=nil)
       classes = {
         'ffi-rzmq' => SessionAdapter::FfirzmqAdapter,
         'cztop' => SessionAdapter::CztopAdapter,
         # 'pyzmq' => SessionAdapter::PyzmqAdapter
+        'test' => SessionAdapter::TestAdapter,
       }
       if (name ||= ENV.fetch('IRUBY_SESSION_ADAPTER', nil))
         cls = classes[name]

--- a/lib/iruby/session_adapter/test_adapter.rb
+++ b/lib/iruby/session_adapter/test_adapter.rb
@@ -1,0 +1,49 @@
+require 'iruby/session/mixin'
+
+module IRuby
+  module SessionAdapter
+    class TestAdapter < BaseAdapter
+      include IRuby::SessionSerialize
+
+      DummySocket = Struct.new(:type, :protocol, :host, :port)
+
+      def initialize(config)
+        super
+
+        unless config['key'].empty? || config['signature_scheme'].empty?
+          unless config['signature_scheme'] =~ /\Ahmac-/
+            raise "Unknown signature_scheme: #{config['signature_scheme']}"
+          end
+          digest_algorithm = config['signature_scheme'][/\Ahmac-(.*)\Z/, 1]
+          @hmac = OpenSSL::HMAC.new(config['key'], OpenSSL::Digest.new(digest_algorithm))
+        end
+
+        @send_callback = nil
+        @recv_callback = nil
+      end
+
+      attr_accessor :send_callback, :recv_callback
+
+      def send(sock, data)
+        unless @send_callback.nil?
+          @send_callback.call(sock, unserialize(data))
+        end
+      end
+
+      def recv(sock)
+        unless @recv_callback.nil?
+          serialize(@recv_callback.call(sock))
+        end
+      end
+
+      def heartbeat_loop(sock)
+      end
+
+      private
+
+      def make_socket(type, protocol, host, port)
+        DummySocket.new(type, protocol, host, port)
+      end
+    end
+  end
+end

--- a/test/iruby/event_manager_test.rb
+++ b/test/iruby/event_manager_test.rb
@@ -1,0 +1,92 @@
+module IRubyTest
+  class EventManagerTest < TestBase
+    def setup
+      @man = IRuby::EventManager.new([:foo, :bar])
+    end
+
+    def test_available_events
+      assert_equal([:foo, :bar],
+                   @man.available_events)
+    end
+
+    sub_test_case("#register") do
+      sub_test_case("known event name") do
+        def test_register
+          fn = ->() {}
+          assert_equal(fn,
+                       @man.register(:foo, &fn))
+        end
+      end
+
+      sub_test_case("unknown event name") do
+        def test_register
+          assert_raise_message("Unknown event name: baz") do
+            @man.register(:baz) {}
+          end
+        end
+      end
+    end
+
+    sub_test_case("#unregister") do
+      sub_test_case("no event is registered") do
+        def test_unregister
+          fn = ->() {}
+          assert_raise_message("Given callable object #{fn} is not registered as a foo callback") do
+            @man.unregister(:foo, fn)
+          end
+        end
+      end
+
+      sub_test_case("the registered callable is given") do
+        def test_unregister
+          results = { values: [] }
+          fn = ->(a) { values << a }
+
+          @man.register(:foo, &fn)
+
+          results[:retval] = @man.unregister(:foo, fn)
+
+          @man.trigger(:foo, 42)
+
+          assert_equal({
+                         values: [],
+                         retval: fn
+                       },
+                       results)
+        end
+      end
+    end
+
+    sub_test_case("#trigger") do
+      sub_test_case("no event is registered") do
+        def test_trigger
+          assert_nothing_raised do
+            @man.trigger(:foo)
+          end
+        end
+      end
+
+      sub_test_case("some events are registered") do
+        def test_trigger
+          values = []
+          @man.register(:foo) {|a| values << a }
+          @man.register(:foo) {|a| values << 10*a }
+          @man.register(:foo) {|a| values << 100+a }
+
+          @man.trigger(:foo, 5)
+
+          assert_equal([5, 50, 105],
+                       values)
+        end
+      end
+
+      sub_test_case("unknown event name") do
+        def test_trigger
+          assert_raise_message("Unknown event name: baz") do
+            @man.trigger(:baz, 100)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/iruby/kernel_test.rb
+++ b/test/iruby/kernel_test.rb
@@ -1,0 +1,80 @@
+require "base64"
+
+module IRubyTest
+  class KernelTest < TestBase
+    def setup
+      super
+      with_session_adapter("test")
+      @kernel = IRuby::Kernel.instance
+    end
+
+    def test_execute_request
+      obj = Object.new
+
+      class << obj
+        def to_html
+          "<b>HTML</b>"
+        end
+
+        def inspect
+          "!!! inspect !!!"
+        end
+      end
+
+      ::IRubyTest.define_singleton_method(:test_object) { obj }
+
+      msg_types = []
+      execute_reply = nil
+      execute_result = nil
+      @kernel.session.adapter.send_callback = ->(sock, msg) do
+        header = msg[:header]
+        content = msg[:content]
+        msg_types << header["msg_type"]
+        case header["msg_type"]
+        when "execute_reply"
+          execute_reply = content
+        when "execute_result"
+          execute_result = content
+        end
+      end
+
+      msg = {
+        content: {
+          "code" => "IRubyTest.test_object",
+          "silent" => false,
+          "store_history" => false,
+          "user_expressions" => {},
+          "allow_stdin" => false,
+          "stop_on_error" => true,
+        }
+      }
+      @kernel.execute_request(msg)
+
+      assert_equal({
+                     msg_types: [ "execute_input", "execute_reply", "execute_result" ],
+                     execute_reply: {
+                       status: "ok",
+                       user_expressions: {},
+                     },
+                     execute_result: {
+                       data: {
+                         "text/html" => "<b>HTML</b>",
+                         "text/plain" => "!!! inspect !!!"
+                       },
+                       metadata: {},
+                     }
+                   },
+                   {
+                     msg_types: msg_types,
+                     execute_reply: {
+                       status: execute_reply["status"],
+                       user_expressions: execute_reply["user_expressions"]
+                     },
+                     execute_result: {
+                       data: execute_result["data"],
+                       metadata: execute_result["metadata"]
+                     }
+                   })
+    end
+  end
+end

--- a/test/iruby/session_test.rb
+++ b/test/iruby/session_test.rb
@@ -38,6 +38,7 @@ module IRubyTest
         stub(IRuby::SessionAdapter::CztopAdapter).available? { false }
         stub(IRuby::SessionAdapter::FfirzmqAdapter).available? { false }
         stub(IRuby::SessionAdapter::PyzmqAdapter).available? { false }
+        stub(IRuby::SessionAdapter::TestAdapter).available? { false }
         assert_raises IRuby::SessionAdapterNotFound do
           IRuby::Session.new(@session_config)
         end

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -14,5 +14,6 @@ $LOAD_PATH.unshift(lib_dir.to_s)
 require_relative "helper"
 
 ENV["TEST_UNIT_MAX_DIFF_TARGET_STRING_SIZE"] ||= "10000"
+ENV["IRUBY_TEST_SESSION_ADAPTER_NAME"] ||= "ffi-rzmq"
 
 exit Test::Unit::AutoRunner.run(true, test_dir)


### PR DESCRIPTION
The following four events are implemented in this pull request.

- `pre_execute` -- occurred before every code execution
- `pre_run_cell` -- occurred before every non-silent code execution
- `post_execute` -- occurred after every code execution
- `post_run_cell` -- occurred after every non-silent code execution

`pre_execute` and `post_execute` events do not take any argument.  `pre_run_cell` event takes one argument, that is an `IRuby::ExecutionInfo` object.  `post_run_cell` event takes one argument, that is the result of the code execution.
