### PR TITLE
Add initialized event

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -5,7 +5,10 @@ module IRuby
     RED = "\e[31m"
     RESET = "\e[0m"
 
-    class<< self
+    @events = EventManager.new([:initialized])
+
+    class << self
+      attr_reader :events
       attr_accessor :instance
     end
 
@@ -33,6 +36,8 @@ module IRuby
       @execution_count = 0
       @backend = create_backend
       @running = true
+
+      self.class.events.trigger(:initialized, self)
     end
 
     attr_reader :events

--- a/test/iruby/kernel_test.rb
+++ b/test/iruby/kernel_test.rb
@@ -8,6 +8,25 @@ module IRubyTest
       @kernel = IRuby::Kernel.instance
     end
 
+    sub_test_case("iruby_initialized event") do
+      def setup
+        super
+        @initialized_kernel = nil
+        @callback = IRuby::Kernel.events.register(:initialized) do |kernel|
+          @initialized_kernel = kernel
+        end
+      end
+
+      def teardown
+        IRuby::Kernel.events.unregister(:initialized, @callback)
+      end
+
+      def test_iruby_initialized_event
+        with_session_adapter("test")
+        assert_same(IRuby::Kernel.instance, @initialized_kernel)
+      end
+    end
+
     def test_execute_request
       obj = Object.new
 


### PR DESCRIPTION
The new event `initialized` is added in `IRuby::Kernel` class.
This event occurs after an `IRuby::Kernel` object is initialized.
The new kernel object is passed to the callable objects registered to the `initialize` event.

This pull request is the redesign of the idea originally proposed by @Yuki-Inoue in #168.