### PR TITLE
Add to_iruby_mimebundle support

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -41,6 +41,7 @@ jobs:
 
     - name: Install requirements on ubuntu
       run: |
+        sudo apt update
         sudo apt install -y --no-install-recommends \
                  libczmq-dev \
                  python3 \

--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -216,10 +216,12 @@ module IRuby
     class TypeFormatMatcher < FormatMatcher
       def initialize(class_block)
         super() do |obj|
-          self.klass === obj
-        # We have to rescue all exceptions since constant autoloading could fail with a different error
-        rescue Exception
-          false
+          begin
+            self.klass === obj
+          # We have to rescue all exceptions since constant autoloading could fail with a different error
+          rescue Exception
+            false
+          end
         end
         @class_block = class_block
       end

--- a/test/iruby/display_test.rb
+++ b/test/iruby/display_test.rb
@@ -131,12 +131,12 @@ module IRubyTest
         def test_display
           assert_iruby_display({
                                  result: {
-                                   "text/html" => "<b>to_iruby</b>",
+                                   "text/markdown" => "*markdown*",
                                    "text/plain" => "!!! inspect !!!"
                                  },
                                  to_html_called: false,
-                                 to_markdown_called: false,
-                                 to_iruby_called: true,
+                                 to_markdown_called: true,
+                                 to_iruby_called: false,
                                  to_iruby_mimebundle_called: false
                                })
         end
@@ -170,12 +170,12 @@ module IRubyTest
           def test_display
             assert_iruby_display({
                                    result: {
-                                     "text/html" => "<b>html</b>",
+                                     "text/html" => "<i>html</i>",
                                      "text/markdown" => "**markdown**",
                                      "application/json" => %Q[{"mimebundle": "json"}],
                                      "text/plain" => "!!! inspect !!!"
                                    },
-                                   to_html_called: true,
+                                   to_html_called: false,
                                    to_markdown_called: false,
                                    to_iruby_called: false,
                                    to_iruby_mimebundle_called: true

--- a/test/iruby/display_test.rb
+++ b/test/iruby/display_test.rb
@@ -1,0 +1,188 @@
+module IRubyTest
+  class DisplayTest < TestBase
+    def setup
+      @object = Object.new
+      @object.instance_variable_set(:@to_html_called, false)
+      @object.instance_variable_set(:@to_markdown_called, false)
+      @object.instance_variable_set(:@to_iruby_called, false)
+      @object.instance_variable_set(:@to_iruby_mimebundle_called, false)
+
+      class << @object
+        attr_reader :to_html_called
+        attr_reader :to_markdown_called
+        attr_reader :to_iruby_called
+        attr_reader :to_iruby_mimebundle_called
+
+        def html
+          "<b>html</b>"
+        end
+
+        def markdown
+          "*markdown*"
+        end
+
+        def inspect
+          "!!! inspect !!!"
+        end
+      end
+    end
+
+    def define_to_html
+      class << @object
+        def to_html
+          @to_html_called = true
+          html
+        end
+      end
+    end
+
+    def define_to_markdown
+      class << @object
+        def to_markdown
+          @to_markdown_called = true
+          markdown
+        end
+      end
+    end
+
+    def define_to_iruby
+      class << @object
+        def to_iruby
+          @to_iruby_called = true
+          ["text/html", "<b>to_iruby</b>"]
+        end
+      end
+    end
+
+    def define_to_iruby_mimebundle
+      class << @object
+        def to_iruby_mimebundle(include: [])
+          @to_iruby_mimebundle_called = true
+          mimes = if include.empty?
+                    ["text/html", "text/markdown", "application/json"]
+                  else
+                    include
+                  end
+          formats = mimes.map { |mime|
+            result = case mime
+                     when "text/html"
+                       "<i>html</i>"
+                     when "text/markdown"
+                       "**markdown**"
+                     when "application/json"
+                       %Q[{"mimebundle": "json"}]
+                     end
+            [mime, result]
+          }.to_h
+          metadata = {}
+          return formats, metadata
+        end
+      end
+    end
+
+    def assert_iruby_display(expected)
+      assert_equal(expected,
+                   {
+                     result: IRuby::Display.display(@object),
+                     to_html_called: @object.to_html_called,
+                     to_markdown_called: @object.to_markdown_called,
+                     to_iruby_called: @object.to_iruby_called,
+                     to_iruby_mimebundle_called: @object.to_iruby_mimebundle_called
+                   })
+    end
+
+    sub_test_case("the object cannot handle all the mime types") do
+      def test_display
+        assert_iruby_display({
+                               result: {"text/plain" => "!!! inspect !!!"},
+                               to_html_called: false,
+                               to_markdown_called: false,
+                               to_iruby_called: false,
+                               to_iruby_mimebundle_called: false
+                             })
+      end
+    end
+
+    sub_test_case("the object can respond to to_iruby") do
+      def setup
+        super
+        define_to_iruby
+      end
+
+      def test_display
+        assert_iruby_display({
+                               result: {
+                                 "text/html" => "<b>to_iruby</b>",
+                                 "text/plain" => "!!! inspect !!!"
+                               },
+                               to_html_called: false,
+                               to_markdown_called: false,
+                               to_iruby_called: true,
+                               to_iruby_mimebundle_called: false
+                             })
+      end
+
+      sub_test_case("the object can respond to to_markdown") do
+        def setup
+          super
+          define_to_markdown
+        end
+
+        def test_display
+          assert_iruby_display({
+                                 result: {
+                                   "text/html" => "<b>to_iruby</b>",
+                                   "text/plain" => "!!! inspect !!!"
+                                 },
+                                 to_html_called: false,
+                                 to_markdown_called: false,
+                                 to_iruby_called: true,
+                                 to_iruby_mimebundle_called: false
+                               })
+        end
+      end
+
+      sub_test_case("the object can respond to to_html") do
+        def setup
+          super
+          define_to_html
+        end
+
+        def test_display
+          assert_iruby_display({
+                                 result: {
+                                   "text/html" => "<b>html</b>",
+                                   "text/plain" => "!!! inspect !!!"
+                                 },
+                                 to_html_called: true,
+                                 to_markdown_called: false,
+                                 to_iruby_called: false,
+                                 to_iruby_mimebundle_called: false
+                               })
+        end
+
+        sub_test_case("the object can respond to to_iruby_mimebundle") do
+          def setup
+            super
+            define_to_iruby_mimebundle
+          end
+
+          def test_display
+            assert_iruby_display({
+                                   result: {
+                                     "text/html" => "<b>html</b>",
+                                     "text/markdown" => "**markdown**",
+                                     "application/json" => %Q[{"mimebundle": "json"}],
+                                     "text/plain" => "!!! inspect !!!"
+                                   },
+                                   to_html_called: true,
+                                   to_markdown_called: false,
+                                   to_iruby_called: false,
+                                   to_iruby_mimebundle_called: true
+                                 })
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce `to_iruby_mimebundle` method support like [IPython's `_repr_mimebundle`](https://ipython.readthedocs.io/en/stable/config/integrating.html#MyObject._repr_mimebundle_).

The new display algorithm is below.

If the object to be displayed can respond to `to_iruby_mimebundle`, IRuby first tries to format the object by this method.
Then, IRuby tries to format the object by the renderers registered in the registry into MIME-types that are not formatted by `to_iruby_mimebundle`.
Moreover, IRuby tries to format the object by `to_xxx` method for the MIME-types that have not been formatted in the following list.

- `text/html` by `to_html` method
- `text/markdown` by `to_markdown` method
- `image/svg+xml` by `to_svg` method
- `image/png` by `to_png` method
- `application/pdf` by `to_pdf` method
- `image/jpeg` by `to_jpeg` method
- `text/latex` by `to_latex` or `to_tex` method
- `application/javascript` by `to_javascript` method

If none of MIME-type are formatted at this time, IRuby tries to format the object by `to_iruby` method.

Finally, IRuby generates the `text/plain` format by `inspect` method if `text/plain` format is not generated yet.