### PR TITLE
Compatibility Issue ruby 2.7 and ruby 3.0

### DIFF
--- a/lib/iruby/utils.rb
+++ b/lib/iruby/utils.rb
@@ -21,7 +21,7 @@ module IRuby
 
     # Format the given object into HTML table
     def table(s, **options)
-      html(HTML.table(s, options))
+      html(HTML.table(s, **options))
     end
 
     # Treat the given string as LaTeX text


### PR DESCRIPTION
A very small change which re-enables the use of IRuby.table in recent ruby versions