### PR TITLE
Use native-package-installer to install zeromq automatically

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,0 +1,15 @@
+task default: :all
+
+task all: [:install_zeromq]
+
+task :install_zeromq do
+  require "native-package-installer"
+
+  NativePackageInstaller.install(arch_linux: "zeromq",
+                                 debian: "libzmq5",
+                                 freebsd: "zeromq4",
+                                 homebrew: "zmq",
+                                 macports: "zmq",
+                                 msys2: "zeromq",
+                                 redhat: "zeromq")
+end

--- a/iruby.gemspec
+++ b/iruby.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^test/})
   s.require_paths = %w[lib]
+  s.extensions    = ["ext/Rakefile"]
 
   s.required_ruby_version = '>= 2.3.0'
 
@@ -23,8 +24,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'mime-types', '>= 3.3.1'
   s.add_dependency 'multi_json', '~> 1.11'
 
+  s.add_runtime_dependency "native-package-installer", ">= 1.0.3"
+
   s.add_development_dependency 'pycall', '>= 1.2.1'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'test-unit-rr'
+
+  s.metadata["msys2_mingw_dependencies"] = "zeromq"
 end


### PR DESCRIPTION
I'd like to install libzmq automatically by `native-package-installer` when a user run `gem install iruby`.

For example in Windows:
<img width="777" alt="Screen Shot 2021-07-20 at 01 25 11" src="https://user-images.githubusercontent.com/3959/126194413-fa31726c-08a1-4ef0-9b65-fb4e081789a2.png">
