### PR TITLE
Hide output on assignment

### DIFF
--- a/lib/iruby/backend.rb
+++ b/lib/iruby/backend.rb
@@ -53,7 +53,7 @@ module IRuby
 
     def eval(code, store_history)
       @irb.context.evaluate(code, 0)
-      @irb.context.last_value
+      @irb.context.last_value unless assignment_expression?(code)
     end
 
     def complete(code)
@@ -68,6 +68,10 @@ module IRuby
       main.define_singleton_method(:include) do |*args|
         wrapper_module.include(*args)
       end
+    end
+
+    def assignment_expression?(code)
+      @irb.respond_to?(:assignment_expression?) && @irb.assignment_expression?(code)
     end
   end
 

--- a/lib/iruby/backend.rb
+++ b/lib/iruby/backend.rb
@@ -1,6 +1,11 @@
 module IRuby
   In, Out = [nil], [nil]
 
+  class << self
+    attr_accessor :silent_assignment
+  end
+  self.silent_assignment = false
+
   module History
     def eval(code, store_history)
       b = eval_binding
@@ -53,7 +58,7 @@ module IRuby
 
     def eval(code, store_history)
       @irb.context.evaluate(code, 0)
-      @irb.context.last_value unless assignment_expression?(code)
+      @irb.context.last_value unless IRuby.silent_assignment && assignment_expression?(code)
     end
 
     def complete(code)


### PR DESCRIPTION
Hi, this PR hides output on assignment (like Python). This avoids the need to add `; nil` to lines. It uses [assignment_expression?](https://github.com/ruby/irb/blob/bd597bcde0858d5ec86f2c5295df4893dc9ff08b/lib/irb.rb#L864) from IRB and checks that it exists first for older versions (added in https://github.com/ruby/irb/commit/0a3a0f5d9ed543440950dfc2a4ad2ec32e66009e).

Ref: #195