### PR TITLE
Add Ruby 3.2 to CI for ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         os:
         - ubuntu-latest
         ruby:
+        - "3.2"
         - "3.1"
         - "3.0"
         - "2.7"


### PR DESCRIPTION
It also may be desirable to update the Ruby for Windows or Mac (or expand the configuration to multiple Rubies).  But I'll leave that up to the discretion of the maintainers.

This runs green on my fork.