### PR TITLE
Default to true for `store_history` if not in silent mode

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -176,8 +176,9 @@ module IRuby
     # @private
     def execute_request(msg)
       code = msg[:content]['code']
-      store_history = msg[:content]['store_history']
       silent = msg[:content]['silent']
+      # https://jupyter-client.readthedocs.io/en/stable/messaging.html#execute
+      store_history = silent ? false : msg[:content].fetch('store_history', true)
 
       @execution_count += 1 if store_history
 


### PR DESCRIPTION
According to the  [documentation](https://jupyter-client.readthedocs.io/en/stable/messaging.html#execute) for `store_history`:

> A boolean flag which, if True, signals the kernel to populate history
The default is True if silent is False.  If silent is True, store_history
is forced to be False.