### PR TITLE
Fixed Ruby 2.5 compatibility

### DIFF
--- a/lib/iruby/session.rb
+++ b/lib/iruby/session.rb
@@ -2,7 +2,6 @@ require 'iruby/session_adapter'
 require 'iruby/session/mixin'
 
 require 'securerandom'
-require 'time'
 
 module IRuby
   class Session
@@ -80,7 +79,7 @@ module IRuby
       header = {
         msg_type: message_type,
         msg_id:   SecureRandom.uuid,
-        date:     Time.now.utc.iso8601,
+        date:     Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
         username: 'kernel',
         session:  @session_id,
         version:  '5.0'


### PR DESCRIPTION
Previous commit d54a6b7 broke Ruby 2.5 compatibility by using `Time#iso8601`. Patching it to use `Time#strftime` instead.