### PR TITLE
Update CI Configuration for IRuby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
           - "3.1"
           - "3.0"
           - "2.7"
-          - "2.6"
-          - "2.5"
           - debug
 
     steps:
@@ -41,15 +39,13 @@ jobs:
 
       - run: rake build
 
-      - name: Install irb for old Ruby
+      - name: Install ffi 1.6 for old Ruby
         if: |
-          matrix.ruby == '2.5' ||
-          matrix.ruby == '2.4' ||
-          matrix.ruby == '2.3'
+          matrix.ruby == '2.7'
         run: |
           cat <<GEMFILE > Gemfile.irb
           source 'https://rubygems.org'
-          gem 'irb'
+          gem 'ffi', '~> 1.6'
           GEMFILE
           BUNDLE_GEMFILE=Gemfile.irb bundle install --jobs 4 --retry 3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - debug
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -104,7 +104,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "ruby"
 
       - run: rake build
 
@@ -110,7 +110,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "ruby"
 
       - run: rake build
 


### PR DESCRIPTION
- Deleted Ruby 2.5 and 2.6 from the CI matrix
- Removed IRB installation logic for older Ruby versions
- Added ffi 1.6 installation for Ruby 2.7
- Update checkout action to v4
- Use the latest ruby version