### PR TITLE
Add logger and Remove base64 to Fix CI Tests

### DIFF
--- a/iruby.gemspec
+++ b/iruby.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'data_uri', '~> 0.1'
   s.add_dependency 'ffi-rzmq'
   s.add_dependency 'irb'
+  s.add_dependency 'logger'
   s.add_dependency 'mime-types', '>= 3.3.1'
   s.add_dependency 'multi_json', '~> 1.11'
   s.add_dependency 'native-package-installer'

--- a/test/iruby/kernel_test.rb
+++ b/test/iruby/kernel_test.rb
@@ -1,5 +1,3 @@
-require "base64"
-
 module IRubyTest
   class KernelTest < TestBase
     def setup


### PR DESCRIPTION
Hi

The current CI fails tests with the latest version of Ruby, specifically `debug`. To pass these tests, the following two fixes are necessary:

1. Remove the unnecessary `require "base64"`

This may be code intended for future changes, but it is not currently used. From Ruby 3.4, `base64` will no longer be a default gem.

2. Add `logger` to dependencies

From Ruby 3.5, `logger` will also no longer be a default gem, so it needs to be explicitly specified as a dependency.

By applying these fixes, the tests will pass.
The minor goal of this pull request is to pass the tests. However, the larger goal is to maintain a state where contributors can easily submit their pull requests.