### PR TITLE
Update CI trigger configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Hi

This pull request changes the CI workflow to run on all branches. Currently, the CI only runs on the master branch. This setup can be a potential barrier for new contributors. By allowing the CI to run on all branches, developers can see if their changes pass CI before submitting a pull request without needing to make any extra changes. Given that the development of SciRuby/iruby is not very active, we do not anticipate any issues with resource consumption. I hope this change will make development easier for everyone.

Thank you.