### PR TITLE
0.8.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,23 @@
+# 0.8.0 (2024-07-28)
+
+* Hide output on assignment by @ankane in https://github.com/SciRuby/iruby/pull/312
+* Introduce the new Application classes by @mrkn in https://github.com/SciRuby/iruby/pull/317
+* Fix Gnuplot issues in Ruby 2.7 (#321) by @kojix2 in https://github.com/SciRuby/iruby/pull/322
+* Add Ruby3.1 to CI by @kojix2 in https://github.com/SciRuby/iruby/pull/323
+* Update README.md by @marek-witkowski in https://github.com/SciRuby/iruby/pull/324
+* ci: upgrade actions/checkout by @kojix2 in https://github.com/SciRuby/iruby/pull/325
+* Add Ruby 3.2 to CI for ubuntu by @petergoldstein in https://github.com/SciRuby/iruby/pull/327
+* Default to true for `store_history` if not in silent mode by @gartens in https://github.com/SciRuby/iruby/pull/330
+* Add Ruby 3.3 to CI for Ubuntu by @kojix2 in https://github.com/SciRuby/iruby/pull/331
+* Remove Ruby 2.3 and 2.4 from CI by @kojix2 in https://github.com/SciRuby/iruby/pull/332
+* Fix typos by @kojix2 in https://github.com/SciRuby/iruby/pull/335
+* Format README.md and ci.yml by @kojix2 in https://github.com/SciRuby/iruby/pull/337
+* Fix PlainBackend for irb v1.13.0 by @zalt50 in https://github.com/SciRuby/iruby/pull/339
+* Added `date` to header by @ebababi in https://github.com/SciRuby/iruby/pull/342
+* Update CI Configuration for IRuby by @kojix2 in https://github.com/SciRuby/iruby/pull/344
+* Add logger and Remove base64 to Fix CI Tests by @kojix2 in https://github.com/SciRuby/iruby/pull/345
+* Update CI trigger configuration by @kojix2 in https://github.com/SciRuby/iruby/pull/346
+
 # 0.7.4 (2021-08-18)
 
 ## Enhancements

--- a/lib/iruby/version.rb
+++ b/lib/iruby/version.rb
@@ -1,3 +1,3 @@
 module IRuby
-  VERSION = '0.7.4'
+  VERSION = '0.8.0'
 end


### PR DESCRIPTION
Hi,

Recently, @bolshakov and @orlando-labs reported that IRuby 0.7.4 does not work after installation ([issue #341](https://github.com/SciRuby/iruby/issues/341)). Also, @rgbkrk suggested that we should include the date in the message header ([issue #340](https://github.com/SciRuby/iruby/issues/340)), and @ebababi submitted a pull request to address this, which has been merged ([PR #342](https://github.com/SciRuby/iruby/pull/342)).

We need to release a new version of IRuby. Initially, I thought it would be better to make some improvements before releasing it, but given the lack of active developers, this would delay or even make it unlikely to release v0.8.0 at all.

Since 0.7.4 is not working well for many people, I think it is okay to release v0.8.0 even if it is not perfect. We will release the current code as v0.8.0 and, as pull requests with fixes come in, we will merge them and release the next version.

This pull request is scheduled to be merged before 03:00 UTC on 2024-07-28.

Thank you for your understanding and cooperation.