### PR TITLE
Add support for jupyter widgets

### DIFF
--- a/lib/iruby/comm.rb
+++ b/lib/iruby/comm.rb
@@ -13,17 +13,17 @@ module IRuby
       @target_name, @comm_id = target_name, comm_id
     end
 
-    def open(**data)
-      Kernel.instance.session.send(:publish, :comm_open, comm_id: @comm_id, data: data, target_name: @target_name)
+    def open(metadata = nil, **data)
+      Kernel.instance.session.send(:publish, :comm_open, metadata, comm_id: @comm_id, data: data, target_name: @target_name)
       Comm.comm[@comm_id] = self
     end
 
-    def send(**data)
-      Kernel.instance.session.send(:publish, :comm_msg, comm_id: @comm_id, data: data)
+    def send(metadata = nil, **data)
+      Kernel.instance.session.send(:publish, :comm_msg, metadata, comm_id: @comm_id, data: data)
     end
 
-    def close(**data)
-      Kernel.instance.session.send(:publish, :comm_close, comm_id: @comm_id, data: data)
+    def close(metadata = nil, **data)
+      Kernel.instance.session.send(:publish, :comm_close, metadata, comm_id: @comm_id, data: data)
       Comm.comm.delete(@comm_id)
     end
 

--- a/lib/iruby/session.rb
+++ b/lib/iruby/session.rb
@@ -70,7 +70,7 @@ module IRuby
       end
     end
 
-    def send(socket_type, message_type, content)
+    def send(socket_type, message_type, metadata = nil, content)
       sock = check_socket_type(socket_type)
       idents = if socket_type == :reply && @last_recvd_msg
                  @last_recvd_msg[:idents]
@@ -85,7 +85,7 @@ module IRuby
         session:  @session_id,
         version:  '5.0'
       }
-      @adapter.send(sock, serialize(idents, header, content))
+      @adapter.send(sock, serialize(idents, header, metadata, content))
     end
 
     def recv(socket_type)

--- a/lib/iruby/session/mixin.rb
+++ b/lib/iruby/session/mixin.rb
@@ -4,10 +4,10 @@ module IRuby
 
     private
 
-    def serialize(idents, header, content)
+    def serialize(idents, header, metadata = nil, content)
       msg = [MultiJson.dump(header),
              MultiJson.dump(@last_recvd_msg ? @last_recvd_msg[:header] : {}),
-             '{}',
+             MultiJson.dump(metadata || {}),
              MultiJson.dump(content || {})]
       frames = ([*idents].compact.map(&:to_s) << DELIM << sign(msg)) + msg
       IRuby.logger.debug "Sent #{frames.inspect}"


### PR DESCRIPTION
Currently it is not possible to display Jupyter widgets with an iruby kernel, as they require custom metadata on comm. This patch adds the ability to send metadata on open, send_msg, and close messages in a backward-compatible fashion. 

As an example, you can now display an IntSlider with this example code, executed in a notebook. Please note the `{:version => "2.1.0"}` - this is metadata that has not been supported until now.

        comm = IRuby::Comm.new("jupyter.widget", comm_id = @id)
 
        comm.open({:version => "2.1.0"}, :state => {
        	:dom_classes => [],
        	:_model_module => "@jupyter-widgets/controls",
        	:_model_module_version => "2.0.0",
        	:_model_name => "IntSliderModel",
        	:_view_count => nil,
        	:_view_module => "@jupyter-widgets/controls",
        	:_view_name => "IntSliderView",
        	:_view_module_version => "2.0.0"
        })
