### PR TITLE
Suppress "literal string will be frozen in the future" warning

### DIFF
--- a/lib/iruby/formatter.rb
+++ b/lib/iruby/formatter.rb
@@ -90,7 +90,7 @@ module IRuby
         rows2 = rows[-maxrows / 2 + 1..-1]
       end
 
-      table = '<table>'
+      table = +'<table>'
 
       if header1 && options[:header] != false
         table << '<tr>' << header1.map {|k| "<th>#{cell k}</th>" }.join


### PR DESCRIPTION
Before change:

```console
$ rake 2>&1 | grep 'iruby.*frozen'
/Users/zzz/src/github.com/SciRuby/iruby/lib/iruby/formatter.rb:128: warning: literal string will be frozen in the future
/Users/zzz/src/github.com/SciRuby/iruby/lib/iruby/formatter.rb:96: warning: literal string will be frozen in the future
```

After change:

```console
$ rake 2>&1 | grep 'iruby.*frozen'
```