### PR TITLE
Fix warnings in project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,8 @@ end
 group :test do
   gem 'cztop'
 end
+
+# Tests are failing on Ruby 3.3 because warnings related to OpenStruct are being written to the standard error output.
+# This is being captured by Open3.capture2e and then mistakenly parsed as JSON.
+# This gem can be removed when json gem is updated
+gem 'ostruct'

--- a/lib/iruby/application.rb
+++ b/lib/iruby/application.rb
@@ -265,7 +265,7 @@ module IRuby
       opts.on(
         "--display-name=VALUE", String,
         "Specify the display name for the kernelspec. This is helpful when you have multiple IRuby kernels."
-      ) {|v| kernel_display_name = v }
+      ) {|v| params.display_name = v }
 
       # TODO: --profile
       # TODO: --prefix

--- a/lib/iruby/backend.rb
+++ b/lib/iruby/backend.rb
@@ -50,6 +50,7 @@ module IRuby
       @irb = IRB::Irb.new(@workspace)
       @eval_path = @irb.context.irb_path
       IRB.conf[:MAIN_CONTEXT] = @irb.context
+      @completor = IRB::RegexpCompletor.new
     end
 
     def eval_binding
@@ -62,7 +63,8 @@ module IRuby
     end
 
     def complete(code)
-      IRB::InputCompletor::CompletionProc.call(code)
+      # preposing and postposing never used, so they are empty, pass only target as code
+      @completor.completion_candidates('', code, '', bind: @workspace.binding)
     end
 
     private

--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -113,14 +113,14 @@ module IRuby
         if FORCE_TEXT_TYPES.include?(mime)
           true
         else
-          MIME::Type.new(mime).ascii?
+          MIME::Type.new("content-type" => mime).ascii?
         end
       end
 
       private def render_mimebundle(obj, exact_mime, fuzzy_mime)
         data = {}
         include_mime = [exact_mime].compact
-        formats, metadata = obj.to_iruby_mimebundle(include: include_mime)
+        formats, _metadata = obj.to_iruby_mimebundle(include: include_mime)
         formats.each do |mime, value|
           if fuzzy_mime.nil? || mime.include?(fuzzy_mime)
             data[mime] = value
@@ -407,7 +407,6 @@ module IRuby
 
       type { Gruff::Base }
       format 'image' do |obj|
-        image = obj.to_image
         format_magick_image.(obj.to_image)
       end
 

--- a/lib/iruby/ostream.rb
+++ b/lib/iruby/ostream.rb
@@ -48,7 +48,7 @@ module IRuby
 
     # Called by irb
     def set_encoding(extern, intern)
-      a = extern
+      extern
     end
 
     private

--- a/test/iruby/application/kernel_test.rb
+++ b/test/iruby/application/kernel_test.rb
@@ -83,7 +83,7 @@ module IRubyTest::ApplicationTests
 
         add_kernel_options("--log=#{log_file}", boot_file)
 
-        out, status = Open3.capture2e(*iruby_command("console"), in: :close)
+        _out, status = Open3.capture2e(*iruby_command("console"), in: :close)
         assert status.success?
         assert_path_exist log_file
         assert_match(/\bINFO -- bootfile: !!! LOG MESSAGE FROM BOOT FILE !!!$/, File.read(log_file))

--- a/test/iruby/application/register_test.rb
+++ b/test/iruby/application/register_test.rb
@@ -61,7 +61,7 @@ puts "Fake Jupyter"
       test("a new IRuby kernel `#{DEFAULT_KERNEL_NAME}` will be installed in JUPYTER_DATA_DIR") do
         assert_path_not_exist @kernel_json
 
-        out, status = Open3.capture2e(*iruby_command("register"))
+        _out, status = Open3.capture2e(*iruby_command("register"))
         assert status.success?
         assert_path_exist @kernel_json
 


### PR DESCRIPTION
- Fixes failing test with `ostruct` warning
- Fixes IRB InputCompletor Deprecation warning
- Fixes parsing `display-name` input param
- Fixes unused variables warnings
- Fixes https://github.com/SciRuby/iruby/issues/352