### PR TITLE
Restore ruby 2.6 and 2.5 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - "3.0"
           - "2.7"
           - "2.6"
+          - "2.5"
           - debug
 
     steps:
@@ -55,6 +56,17 @@ jobs:
           cat <<GEMFILE > Gemfile.irb
           source 'https://rubygems.org'
           gem 'ffi', '~> 1.6.0'
+          GEMFILE
+          BUNDLE_GEMFILE=Gemfile.irb bundle install --jobs 4 --retry 3
+
+      - name: Install ffi 1.6.x and irb < 1.4.3 (if Ruby 2.5)
+        if: |
+          matrix.ruby == '2.5'
+        run: |
+          cat <<GEMFILE > Gemfile.irb
+          source 'https://rubygems.org'
+          gem 'ffi', '~> 1.6.0'
+          gem 'irb', '< 1.4.3'
           GEMFILE
           BUNDLE_GEMFILE=Gemfile.irb bundle install --jobs 4 --retry 3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.1"
           - "3.0"
           - "2.7"
+          - "2.6"
           - debug
 
     steps:
@@ -37,13 +38,23 @@ jobs:
 
       - run: rake build
 
-      - name: Install ffi 1.6 for old Ruby
+      - name: Install ffi (if Ruby 2.7)
         if: |
           matrix.ruby == '2.7'
         run: |
           cat <<GEMFILE > Gemfile.irb
           source 'https://rubygems.org'
-          gem 'ffi', '~> 1.6'
+          gem 'ffi'
+          GEMFILE
+          BUNDLE_GEMFILE=Gemfile.irb bundle install --jobs 4 --retry 3
+
+      - name: Install ffi 1.6.x (if Ruby 2.6)
+        if: |
+          matrix.ruby == '2.6'
+        run: |
+          cat <<GEMFILE > Gemfile.irb
+          source 'https://rubygems.org'
+          gem 'ffi', '~> 1.6.0'
           GEMFILE
           BUNDLE_GEMFILE=Gemfile.irb bundle install --jobs 4 --retry 3
 


### PR DESCRIPTION
Follow-on to #344.

This PR tests/documents running Ruby 2.6 and 2.5.