### PR TITLE
Fix NoMethodError in backend

### DIFF
--- a/lib/iruby/backend.rb
+++ b/lib/iruby/backend.rb
@@ -58,12 +58,14 @@ module IRuby
     end
 
     def eval(code, store_history)
-      if Gem::Version.new(IRB::VERSION) < Gem::Version.new('1.13.0')
-        @irb.context.evaluate(code, 0)
-      else
-        @irb.context.evaluate(@irb.build_statement(code), 0)
-      end
+      @irb.context.evaluate(parse_code(code), 0)
       @irb.context.last_value unless IRuby.silent_assignment && assignment_expression?(code)
+    end
+
+    def parse_code(code)
+      return code if Gem::Version.new(IRB::VERSION) < Gem::Version.new('1.13.0')
+      return @irb.parse_input(code) if @irb.respond_to?(:parse_input)
+      return @irb.build_statement(code) if @irb.respond_to?(:build_statement)
     end
 
     def complete(code)


### PR DESCRIPTION
- [IRB v1.15.0 renamed build_statement -> parse_input](https://github.com/ruby/irb/commit/9fc14eb74bc447108683bc830eb169369d3994d2)

I didn't include any new tests as this existing test was failing when run with IRB >= 1.15.0

```
Error: test_eval_one_plus_two(IRubyTest::PlainBackendTest): NoMethodError: undefined method `build_statement' for an instance of IRB::Irb
/Users/eirik/github.com/edsinclair/iruby/lib/iruby/backend.rb:64:in `eval'
/Users/eirik/github.com/edsinclair/iruby/lib/iruby/backend.rb:16:in `eval'
/Users/eirik/github.com/edsinclair/iruby/test/iruby/backend_test.rb:8:in `test_eval_one_plus_two'
      5:     end
      6:
      7:     def test_eval_one_plus_two
  =>  8:       assert_equal 3, @plainbackend.eval('1+2', false)
      9:     end
     10:
     11:     def test_include_module
============================================================================================================================================================
F
============================================================================================================================================================
Failure: test_include_module(IRubyTest::PlainBackendTest):
  Exception raised:
  NoMethodError(<undefined method `build_statement' for an instance of IRB::Irb>)

```
