### PR TITLE
0.8.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# 0.8.1 (2025-02-16)
+
+* Add support for jupyter widgets by @matt-do-it in https://github.com/SciRuby/iruby/pull/350
+* Suppress "literal string will be frozen in the future" warning by @tikkss in https://github.com/SciRuby/iruby/pull/353
+* Fix warnings in project by @simpl1g in https://github.com/SciRuby/iruby/pull/356
+* restore support for IRB <= v1.13.0 by @sealocal in https://github.com/SciRuby/iruby/pull/358
+* Restore ruby 2.6 and 2.5 in CI by @sealocal in https://github.com/SciRuby/iruby/pull/359
+* Add Ruby 3.4 to CI by @kojix2 in https://github.com/SciRuby/iruby/pull/360
+* Fix NoMethodError in backend by @edsinclair in https://github.com/SciRuby/iruby/pull/364
+
 # 0.8.0 (2024-07-28)
 
 * Hide output on assignment by @ankane in https://github.com/SciRuby/iruby/pull/312

--- a/lib/iruby/version.rb
+++ b/lib/iruby/version.rb
@@ -1,3 +1,3 @@
 module IRuby
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end


### PR DESCRIPTION
Hi,

Recently, @edsinclair reported that IRuby stopped working because  the `build_statement` method was removed in IRB v1.15.0 and later (Issue #363). @edsinclair fixed this issue by checking the IRB version and using the correct method (`parse_input` or `build_statement`) (PR #364).

Later, the same issue was reported again (Issue #365). Since many users are affected, we will release a new version.

Also, @sealocal has joined as a new IRuby committer.

We will continue to merge fixes and release updates as needed.