### PR TITLE
Update CI to refresh apt packages before installing IRuby gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,10 @@ jobs:
           GEMFILE
           BUNDLE_GEMFILE=Gemfile.irb bundle install --jobs 4 --retry 3
 
-      - run: gem install pkg/*.gem
+      - name: Install IRuby gem
+        run: |
+          sudo apt update # Preparation for Native Package Installer
+          gem install pkg/*.gem
 
       - run: ruby -r iruby -e "p IRuby::SessionAdapter.select_adapter_class"
         env:


### PR DESCRIPTION
IRuby automatically installs the required `libzmq3-dev` package based on the platform. It uses a `Rakefile` with `native-package-installer` to handle this.  

https://github.com/SciRuby/iruby/blob/c95d162260e73aa94ba66be80518294c4d3b1700/ext/Rakefile#L5-L19

Currently, many tests are failing because `apt-get install` shows a `--fix-missing` error. This happens when package lists are outdated.  

https://github.com/SciRuby/iruby/actions/runs/13353020518

```
Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

This issue is resolved by running `apt update` before installation.  

```yaml
      - name: Install IRuby gem
        run: |
          sudo apt update
          gem install pkg/*.gem
```

This ensures the package list is up to date and prevents installation failures.  