### PR TITLE
Fix missing `OStream#closed?` method

### DIFF
--- a/lib/iruby/ostream.rb
+++ b/lib/iruby/ostream.rb
@@ -11,6 +11,10 @@ module IRuby
       @session = nil
     end
 
+    def closed?
+      @session.nil?
+    end
+
     def flush
     end
 


### PR DESCRIPTION
Currently with Ruby 3.4.1 and bundler 2.6.2, when `require`ing a Rails application, I get the following error:

```rb
require 'path_to_application/config/application'
```
```
NoMethodError: undefined method 'closed?' for an instance of IRuby::OStream
[/opt/rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/ui/shell.rb:145](http://localhost:8888/opt/rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/ui/shell.rb#line=144):in 'Bundler::UI::Shell#tell_err'
[/opt/rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/ui/shell.rb:49](http://localhost:8888/opt/rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/ui/shell.rb#line=48):in 'Bundler::UI::Shell#error'
[/opt/rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/setup.rb:18](http://localhost:8888/opt/rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/setup.rb#line=17):in '<top (required)>'
```

Bundler is calling `closed?` on `stderr` https://github.com/rubygems/rubygems/blob/v3.6.2/bundler/lib/bundler/ui/shell.rb#L145

`stderr` is an instance of `IRuby::OStream`

Ruby's `IO` implements the `closed?` method: https://docs.ruby-lang.org/en/master/IO.html#method-i-closed-3F

The fix for this is to implement the `closed?` method. With this implementation in place, Bundler is able to run its setup.