### PR TITLE
Various typo corrections

### DIFF
--- a/lib/iruby/application.rb
+++ b/lib/iruby/application.rb
@@ -225,7 +225,7 @@ module IRuby
       end
 
       if ipython_dir
-        File.join(ipython_dir, 'kerenels')
+        File.join(ipython_dir, 'kernels')
       else
         Jupyter.kernelspec_dir
       end

--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -7,7 +7,7 @@ module IRuby
       "text/markdown" => :to_markdown,
       "image/svg+xml" => :to_svg,
       "image/png" => :to_png,
-      "appliation/pdf" => :to_pdf,
+      "application/pdf" => :to_pdf,
       "image/jpeg" => :to_jpeg,
       "text/latex" => [:to_latex, :to_tex],
       # NOTE: Do not include the entry of "application/json" because

--- a/lib/iruby/session_adapter.rb
+++ b/lib/iruby/session_adapter.rb
@@ -60,7 +60,7 @@ module IRuby
           end
         end
         if name == 'cztop'
-          warn "WARNING: cztop was deprecated and will be removed; Use ffi-rzmq, instead."
+          warn "WARNING: cztop is deprecated and will be removed; Use ffi-rzmq instead."
         end
         return cls
       end

--- a/run-test.sh
+++ b/run-test.sh
@@ -4,7 +4,7 @@ set -ex
 
 export PYTHON=python3
 
-ADAPTERS="cztop ffi-rzmq pyzmq"
+ADAPTERS="cztop ffi-rzmq"
 
 for adapter in $ADAPTERS; do
   export IRUBY_TEST_SESSION_ADAPTER_NAME=$adapter

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -38,7 +38,7 @@ class IRubyTest::IntegrationTest < IRubyTest::TestBase
   end
 
   def test_interaction
-    omit("This test too much unstable")
+    omit("This test is too unstable")
 
     write '"Hello, world!"'
     expect '"Hello, world!"'


### PR DESCRIPTION
The VSCode + CLINE review uncovered several typos that will be corrected.
pyzmq adapter has been removed as it does not actually exist