### PR TITLE
0.8.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 0.8.2 (2025-04-10)
+
+* Update CI to refresh apt packages before installing IRuby gem by @kojix2 in https://github.com/SciRuby/iruby/pull/367
+* Fix missing `OStream#closed?` method by @RobinDaugherty in https://github.com/SciRuby/iruby/pull/368
+* Use rubygems-requirements-system to install system dependencies automatically by @kou in https://github.com/SciRuby/iruby/pull/369
+* Various typo corrections by @kojix2 in https://github.com/SciRuby/iruby/pull/370
+* Minor changes to README by @kojix2 in https://github.com/SciRuby/iruby/pull/371
+
 # 0.8.1 (2025-02-16)
 
 * Add support for jupyter widgets by @matt-do-it in https://github.com/SciRuby/iruby/pull/350

--- a/lib/iruby/version.rb
+++ b/lib/iruby/version.rb
@@ -1,3 +1,3 @@
 module IRuby
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end


### PR DESCRIPTION
This release comes ahead of [RubyKaigi 2025](https://rubykaigi.org/2025/).

@kou has replaced [native-package-installer](https://github.com/ruby-gnome/native-package-installer) with [rubygems-requirements-system](https://github.com/ruby-gnome/rubygems-requirements-system/). Previously, IRuby used native-package-installer to automatically install [ZeroMQ](https://zeromq.org/), but this process has now been slightly changed. As a result, there may be some confusion around how to install IRuby.

However, [a coding meetup](https://andpad.connpass.com/event/347970/) is scheduled for the evening of the third day of RubyKaigi 2025. If any issues are discovered there, they are expected to be quickly reported back to the IRuby project.

This release also includes a fix from @RobinDaugherty in #349, which was merged by @sealocal.