### PR TITLE
Remove MultiJson dependency and replace with JSON

### DIFF
--- a/iruby.gemspec
+++ b/iruby.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'irb'
   s.add_dependency 'logger'
   s.add_dependency 'mime-types', '>= 3.3.1'
-  s.add_dependency 'multi_json', '~> 1.11'
 
   s.add_development_dependency 'pycall', '>= 1.2.1'
   s.add_development_dependency 'rake'

--- a/lib/iruby.rb
+++ b/lib/iruby.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 require 'mime/types'
-require 'multi_json'
+require 'json'
 require 'securerandom'
 require 'openssl'
 require 'tempfile'

--- a/lib/iruby/input/form.rb
+++ b/lib/iruby/input/form.rb
@@ -63,7 +63,7 @@ module IRuby
       end
 
       def submit
-        result = MultiJson.load(Kernel.instance.session.recv_input)
+        result = JSON.parse(Kernel.instance.session.recv_input)
 
         unless result.has_key? @id
           submit

--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -38,7 +38,7 @@ module IRuby
     ].freeze
 
     def initialize(config_file, session_adapter_name=nil)
-      @config = MultiJson.load(File.read(config_file))
+      @config = JSON.parse(File.read(config_file))
       IRuby.logger.debug("IRuby kernel start with config #{@config}")
       Kernel.instance = self
 

--- a/lib/iruby/session/mixin.rb
+++ b/lib/iruby/session/mixin.rb
@@ -5,10 +5,10 @@ module IRuby
     private
 
     def serialize(idents, header, metadata = nil, content)
-      msg = [MultiJson.dump(header),
-             MultiJson.dump(@last_recvd_msg ? @last_recvd_msg[:header] : {}),
-             MultiJson.dump(metadata || {}),
-             MultiJson.dump(content || {})]
+      msg = [JSON.generate(header),
+             JSON.generate(@last_recvd_msg ? @last_recvd_msg[:header] : {}),
+             JSON.generate(metadata || {}),
+             JSON.generate(content || {})]
       frames = ([*idents].compact.map(&:to_s) << DELIM << sign(msg)) + msg
       IRuby.logger.debug "Sent #{frames.inspect}"
       frames
@@ -28,10 +28,10 @@ module IRuby
       raise 'Invalid signature' unless s == sign(msg_list[1..-1])
       {
         idents:        idents,
-        header:        MultiJson.load(header),
-        parent_header: MultiJson.load(parent_header),
-        metadata:      MultiJson.load(metadata),
-        content:       MultiJson.load(content),
+        header:        JSON.parse(header),
+        parent_header: JSON.parse(parent_header),
+        metadata:      JSON.parse(metadata),
+        content:       JSON.parse(content),
         buffers:       buffers
       }
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,5 @@
 require "iruby"
 require "json"
-require 'multi_json'
 require "pathname"
 require "rbconfig"
 require "test/unit"


### PR DESCRIPTION
Hi.
[MultiJson](https://github.com/sferik/multi_json) has ended support for Ruby versions earlier than 3.0.
Previous reports indicate that IRuby is often used with older versions of Ruby.
We will migrate from MultiJson to the standard library [JSON](https://github.com/ruby/json).
