### PR TITLE
Daemonize heartbeat thread

### DIFF
--- a/lib/iruby/session.rb
+++ b/lib/iruby/session.rb
@@ -57,6 +57,8 @@ module IRuby
           IRuby.logger.fatal "Kernel heartbeat died: #{e.message}\n#{e.backtrace.join("\n")}"
         end
       end
+      # Avoid process hang at exit on Ruby 3.4+ when this thread blocks
+      @heartbeat_thread.daemon = true
     end
 
     def setup_security

--- a/lib/iruby/session/ffi_rzmq.rb
+++ b/lib/iruby/session/ffi_rzmq.rb
@@ -17,7 +17,7 @@ module IRuby
       stdin_socket = c.socket(ZMQ::XREP)
       stdin_socket.bind(connection % config['stdin_port'])
 
-      Thread.new do
+      hb_thr = Thread.new do
         begin
           hb_socket = c.socket(ZMQ::REP)
           hb_socket.bind(connection % config['hb_port'])
@@ -26,6 +26,7 @@ module IRuby
           IRuby.logger.fatal "Kernel heartbeat died: #{e.message}\n#{e.backtrace.join("\n")}"
         end
       end
+      hb_thr.daemon = true
 
       @sockets = { 
         publish: pub_socket, reply: reply_socket, stdin: stdin_socket


### PR DESCRIPTION
- IRuby’s heartbeat uses ZMQ::Device (zmq_proxy) which blocks indefinitely.
- On Ruby 3.4, a non-daemon blocking thread prevents process exit.
- Mark the heartbeat thread as daemon to avoid exit hang while keeping behavior unchanged.

As a step towards fixing #137