### PR TITLE
Avoid conflict with Ruby's numbered parameters

### DIFF
--- a/lib/iruby/backend.rb
+++ b/lib/iruby/backend.rb
@@ -18,7 +18,7 @@ module IRuby
       # TODO Add IRuby.cache_size which controls the size of the Out array
       # and sets the oldest entries and _<n> variables to nil.
       if store_history
-        b.local_variable_set("_#{Out.size}", out)
+        b.local_variable_set("_o#{Out.size}", out)
         b.local_variable_set("_i#{In.size}", code)
 
         Out << out


### PR DESCRIPTION
`Binding#local_variables` does no longer include numbered parameters like `_1` in Ruby4. See https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/ .