### PR TITLE
Remove CI requirements file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
                    python3-pip \
                    python3-setuptools
           sudo pip3 install wheel
-          sudo pip3 install -r ci/requirements.txt
+          sudo pip3 install jupyter-console
 
       - run: bundle install --jobs 4 --retry 3
 

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,1 +1,0 @@
-jupyter-console>=6.0.0


### PR DESCRIPTION
Make the CI only Python dependency explicit in the workflow.