### PR TITLE
Add explicit session cleanup

### DIFF
--- a/lib/iruby/kernel.rb
+++ b/lib/iruby/kernel.rb
@@ -126,6 +126,13 @@ module IRuby
       while @running
         dispatch
       end
+    ensure
+      close
+    end
+
+    def close
+      @session&.close
+      stop_parent_process_poller
     end
 
     # @private
@@ -312,6 +319,13 @@ module IRuby
       else
         @parent_poller = start_parent_process_pollar_unix
       end
+    end
+
+    def stop_parent_process_poller
+      return unless @parent_poller&.alive?
+
+      @parent_poller.kill
+      @parent_poller.join
     end
 
     def start_parent_process_pollar_unix

--- a/lib/iruby/session.rb
+++ b/lib/iruby/session.rb
@@ -40,6 +40,7 @@ module IRuby
       end
     end
 
+    # Optional setup hook.
     def setup
     end
 

--- a/lib/iruby/session.rb
+++ b/lib/iruby/session.rb
@@ -25,6 +25,21 @@ module IRuby
       "#{@adapter.name} session adapter"
     end
 
+    def close
+      return if @closed
+
+      @closed = true
+      begin
+        close_sockets
+      ensure
+        begin
+          @adapter.close
+        ensure
+          stop_heartbeat
+        end
+      end
+    end
+
     def setup
     end
 
@@ -54,7 +69,7 @@ module IRuby
           # NOTE: this loop is copied from CZTop's old session code
           @adapter.heartbeat_loop(@hb_socket)
         rescue Exception => e
-          IRuby.logger.fatal "Kernel heartbeat died: #{e.message}\n#{e.backtrace.join("\n")}"
+          IRuby.logger.fatal "Kernel heartbeat died: #{e.message}\n#{e.backtrace.join("\n")}" unless @closed
         end
       end
     end
@@ -101,6 +116,22 @@ module IRuby
     end
 
     private
+
+    def close_sockets
+      ([*@sockets&.values, @hb_socket].compact).each do |socket|
+        @adapter.close_socket(socket)
+      end
+    end
+
+    def stop_heartbeat
+      return unless @heartbeat_thread&.alive?
+
+      @heartbeat_thread.join(1)
+      return unless @heartbeat_thread.alive?
+
+      @heartbeat_thread.kill
+      @heartbeat_thread.join
+    end
 
     def check_socket_type(socket_type)
       case socket_type

--- a/lib/iruby/session_adapter.rb
+++ b/lib/iruby/session_adapter.rb
@@ -36,6 +36,13 @@ module IRuby
         socket, port = make_socket(:REP, protocol, host, port)
         [socket, port]
       end
+
+      def close_socket(socket)
+        socket.close if socket.respond_to?(:close)
+      end
+
+      def close
+      end
     end
 
     require_relative 'session_adapter/ffirzmq_adapter'

--- a/lib/iruby/session_adapter.rb
+++ b/lib/iruby/session_adapter.rb
@@ -41,6 +41,7 @@ module IRuby
         socket.close if socket.respond_to?(:close)
       end
 
+      # Override in adapters that need cleanup.
       def close
       end
     end

--- a/lib/iruby/session_adapter/ffirzmq_adapter.rb
+++ b/lib/iruby/session_adapter/ffirzmq_adapter.rb
@@ -29,6 +29,11 @@ module IRuby
         @heartbeat_device = ZMQ::Device.new(sock, sock)
       end
 
+      def close
+        @zmq_context&.terminate
+        @zmq_context = nil
+      end
+
       private
 
       def make_socket(type, protocol, host, port)

--- a/lib/iruby/session_adapter/test_adapter.rb
+++ b/lib/iruby/session_adapter/test_adapter.rb
@@ -20,9 +20,12 @@ module IRuby
 
         @send_callback = nil
         @recv_callback = nil
+        @closed_sockets = []
+        @closed = false
       end
 
       attr_accessor :send_callback, :recv_callback
+      attr_reader :closed_sockets, :closed
 
       def send(sock, data)
         unless @send_callback.nil?
@@ -37,6 +40,15 @@ module IRuby
       end
 
       def heartbeat_loop(sock)
+        sleep 0.01 until @closed
+      end
+
+      def close_socket(sock)
+        @closed_sockets << sock
+      end
+
+      def close
+        @closed = true
       end
 
       private

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -60,10 +60,12 @@ module IRubyTest
     end
 
     def teardown
+      IRuby::Kernel.instance&.close
       self.class.restore_kernel
     end
 
     def with_session_adapter(session_adapter_name)
+      IRuby::Kernel.instance&.close
       IRuby::Kernel.new(self.class.test_config_filename, session_adapter_name)
       $stdout = STDOUT
       $stderr = STDERR

--- a/test/iruby/kernel_test.rb
+++ b/test/iruby/kernel_test.rb
@@ -17,6 +17,7 @@ module IRubyTest
 
       def teardown
         IRuby::Kernel.events.unregister(:initialized, @callback)
+        super
       end
 
       def test_iruby_initialized_event

--- a/test/iruby/session_test.rb
+++ b/test/iruby/session_test.rb
@@ -40,5 +40,24 @@ module IRubyTest
         end
       end
     end
+
+    def test_close_releases_adapter_resources
+      session = IRuby::Session.new(@session_config, "test")
+      adapter = session.adapter
+
+      session.close
+
+      assert(adapter.closed)
+      assert_equal([
+                     :PUB,
+                     :REP,
+                     :ROUTER,
+                     :ROUTER,
+                   ],
+                   adapter.closed_sockets.map(&:type).sort_by(&:to_s))
+      refute(session.instance_variable_get(:@heartbeat_thread).alive?)
+    ensure
+      session&.close
+    end
   end
 end


### PR DESCRIPTION
Add an explicit cleanup path for IRuby sessions.

- Add Session#close and adapter cleanup hooks
- Close sessions from kernel and test teardown paths
- Terminate the ffi-rzmq context on close

Previously, `Session` created ZMQ sockets and a heartbeat thread, but did not provide a `close` method to release them. This could leave ffi-rzmq resources alive after tests finish, contributing to the Ruby 3.4 CI hang. (https://github.com/SciRuby/iruby/issues/357)

This pull request was prepared with assistance from Codex.

---
A follow-up change should replace the current `ZMQ::Device` heartbeat with an explicit poll/echo loop, now that sessions have a cleanup path.