### PR TITLE
Use raw zmq_proxy for ffi-rzmq heartbeat

### DIFF
--- a/lib/iruby/session.rb
+++ b/lib/iruby/session.rb
@@ -123,7 +123,7 @@ module IRuby
     private
 
     def close_sockets
-      ([*@sockets&.values, @hb_socket].compact).each do |socket|
+      @sockets&.values&.each do |socket|
         @adapter.close_socket(socket)
       end
     end

--- a/lib/iruby/session.rb
+++ b/lib/iruby/session.rb
@@ -30,12 +30,16 @@ module IRuby
 
       @closed = true
       begin
-        close_sockets
+        @adapter.shutdown_heartbeat(@hb_socket) if @hb_socket
       ensure
         begin
-          @adapter.close
-        ensure
           stop_heartbeat
+        ensure
+          begin
+            close_sockets
+          ensure
+            @adapter.close
+          end
         end
       end
     end

--- a/lib/iruby/session_adapter.rb
+++ b/lib/iruby/session_adapter.rb
@@ -41,6 +41,10 @@ module IRuby
         socket.close if socket.respond_to?(:close)
       end
 
+      def shutdown_heartbeat(socket)
+        close_socket(socket)
+      end
+
       # Override in adapters that need cleanup.
       def close
       end

--- a/lib/iruby/session_adapter/ffirzmq_adapter.rb
+++ b/lib/iruby/session_adapter/ffirzmq_adapter.rb
@@ -37,9 +37,8 @@ module IRuby
       def shutdown_heartbeat(sock)
         if @zmq_context&.context && LibZMQ.respond_to?(:zmq_ctx_shutdown)
           LibZMQ.zmq_ctx_shutdown(@zmq_context.context)
-        else
-          close_socket(sock)
         end
+        close_socket(sock)
       end
 
       def close

--- a/lib/iruby/session_adapter/ffirzmq_adapter.rb
+++ b/lib/iruby/session_adapter/ffirzmq_adapter.rb
@@ -26,7 +26,20 @@ module IRuby
       end
 
       def heartbeat_loop(sock)
-        @heartbeat_device = ZMQ::Device.new(sock, sock)
+        # Avoid ZMQ::Device in #357; call libzmq's proxy directly.
+        rc = LibZMQ.zmq_proxy(sock.socket, sock.socket, nil)
+        errno = ZMQ::Util.errno
+        return if rc == -1 && (zmq_errno?(:ETERM, errno) || zmq_errno?(:EINTR, errno))
+
+        ZMQ::Util.error_check('zmq_proxy', rc)
+      end
+
+      def shutdown_heartbeat(sock)
+        if @zmq_context&.context && LibZMQ.respond_to?(:zmq_ctx_shutdown)
+          LibZMQ.zmq_ctx_shutdown(@zmq_context.context)
+        else
+          close_socket(sock)
+        end
       end
 
       def close
@@ -36,24 +49,29 @@ module IRuby
 
       private
 
-      def make_socket(type, protocol, host, port)
-        case type
+      def make_socket(type_symbol, protocol, host, port)
+        case type_symbol
         when :ROUTER, :PUB, :REP
-          type = ZMQ.const_get(type)
+          type = ZMQ.const_get(type_symbol)
         else
-          if ZMQ.const_defined?(type)
-            raise ArgumentError, "Unsupported ZMQ socket type: #{type}"
+          if ZMQ.const_defined?(type_symbol)
+            raise ArgumentError, "Unsupported ZMQ socket type: #{type_symbol}"
           else
-            raise ArgumentError, "Invalid ZMQ socket type: #{type}"
+            raise ArgumentError, "Invalid ZMQ socket type: #{type_symbol}"
           end
         end
         zmq_context.socket(type).tap do |sock|
+          sock.setsockopt(ZMQ::LINGER, 0) if type_symbol == :REP
           sock.bind("#{protocol}://#{host}:#{port}")
         end
       end
 
       def zmq_context
         @zmq_context ||= ZMQ::Context.new
+      end
+
+      def zmq_errno?(name, errno)
+        ZMQ.const_defined?(name) && ZMQ.const_get(name) == errno
       end
     end
   end

--- a/lib/iruby/session_adapter/test_adapter.rb
+++ b/lib/iruby/session_adapter/test_adapter.rb
@@ -48,7 +48,7 @@ module IRuby
       end
 
       def close_socket(sock)
-        @closed_sockets << sock unless @closed_sockets.any? { |closed| closed.equal?(sock) }
+        @closed_sockets << sock
       end
 
       def shutdown_heartbeat(sock)

--- a/lib/iruby/session_adapter/test_adapter.rb
+++ b/lib/iruby/session_adapter/test_adapter.rb
@@ -48,7 +48,12 @@ module IRuby
       end
 
       def close_socket(sock)
-        @closed_sockets << sock
+        @closed_sockets << sock unless @closed_sockets.any? { |closed| closed.equal?(sock) }
+      end
+
+      def shutdown_heartbeat(sock)
+        @closed = true
+        close_socket(sock)
       end
 
       def close

--- a/test/iruby/session_test.rb
+++ b/test/iruby/session_test.rb
@@ -30,6 +30,16 @@ module IRubyTest
       assert_equal(adapter_class, selected_class)
     end
 
+    def test_new_with_session_adapter_closes_heartbeat
+      adapter_name = ENV['IRUBY_TEST_SESSION_ADAPTER_NAME']
+      session = IRuby::Session.new(@session_config, adapter_name)
+
+      session.close
+      refute(session.instance_variable_get(:@heartbeat_thread).alive?)
+    ensure
+      session&.close
+    end
+
     def test_without_any_session_adapter
       assert_rr do
         stub(IRuby::SessionAdapter::CztopAdapter).available? { false }

--- a/test/iruby/session_test.rb
+++ b/test/iruby/session_test.rb
@@ -32,6 +32,8 @@ module IRubyTest
 
     def test_new_with_session_adapter_closes_heartbeat
       adapter_name = ENV['IRUBY_TEST_SESSION_ADAPTER_NAME']
+      omit("ffi-rzmq only") unless adapter_name == 'ffi-rzmq'
+
       session = IRuby::Session.new(@session_config, adapter_name)
 
       session.close


### PR DESCRIPTION
- Replace ZMQ::Device with LibZMQ.zmq_proxy
- Stop heartbeat with zmq_ctx_shutdown before closing sockets
- Treat ETERM and EINTR from zmq_proxy as normal shutdown
- Set zero linger on the ffi-rzmq heartbeat socket
- Add a Session close test for the live heartbeat path

This addresses #357. The ffi-rzmq heartbeat still uses libzmq's proxy behavior, but avoids the ZMQ::Device wrapper and gives Session#close an explicit path to stop the heartbeat thread.