### PR TITLE
v0.8.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+# 0.8.3 (2026-06-30)
+
+* Remove MultiJson dependency and replace with JSON by @kojix2 in https://github.com/SciRuby/iruby/pull/373
+* Fix undefined var in FfirzmqAdapter by @kojix2 in https://github.com/SciRuby/iruby/pull/377
+* Avoid conflict with Ruby's numbered parameters by @zalt50 in https://github.com/SciRuby/iruby/pull/380
+* Remove legacy IRUBY_OLD_SESSION session implementations by @kojix2 in https://github.com/SciRuby/iruby/pull/384
+* Add explicit session cleanup by @kojix2 in https://github.com/SciRuby/iruby/pull/388
+* Use raw zmq_proxy for ffi-rzmq heartbeat by @kojix2 in https://github.com/SciRuby/iruby/pull/391
+* Remove obsolete PyCall dependency by @kojix2 in https://github.com/SciRuby/iruby/pull/393
+* Add Ruby 4.0 to CI workflow matrix by @kojix2 in https://github.com/SciRuby/iruby/pull/394
+
 # 0.8.2 (2025-04-10)
 
 * Update CI to refresh apt packages before installing IRuby gem by @kojix2 in https://github.com/SciRuby/iruby/pull/367

--- a/lib/iruby/version.rb
+++ b/lib/iruby/version.rb
@@ -1,3 +1,3 @@
 module IRuby
-  VERSION = '0.8.2'
+  VERSION = '0.8.3'
 end


### PR DESCRIPTION
v0.8.3 is a maintenance release.

This release removes the MultiJson dependency and uses Ruby's standard JSON library instead. It also removes the obsolete PyCall dependency.

The legacy `IRUBY_OLD_SESSION` implementations have been removed. Session cleanup is now handled explicitly. The ffi-rzmq heartbeat path now uses raw `zmq_proxy`.

Thanks to @zalt50 for fixing a conflict with Ruby's numbered parameters.